### PR TITLE
Upgrade to Tempest 3, add test suite, fix command registration (0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 [![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)](https://github.com/tempcord/framework)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![PHP Version](https://img.shields.io/badge/php-%5E8.3-blue.svg)](https://php.net)
+[![PHP Version](https://img.shields.io/badge/php-%5E8.5-blue.svg)](https://php.net)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](#)
 
 ## Description
 
 Tempcord is a modern, elegant PHP framework designed specifically for building Discord bots with ease. Built on top of the powerful Tempest Console framework and Ragnarok Fenrir Discord library, Tempcord provides a clean, attribute-based approach to creating sophisticated Discord bots with minimal boilerplate code.
 
-The framework leverages PHP 8.3+ features and modern development practices to deliver a robust foundation for Discord bot development, featuring automatic command registration, event handling, and seamless integration with Discord's API.
+The framework leverages PHP 8.5+ features and modern development practices to deliver a robust foundation for Discord bot development, featuring automatic command registration, event handling, and seamless integration with Discord's API.
 
 > **Getting Started**: Use the `tempcord/tempcord` boilerplate to quickly create new Discord bot applications. This repository contains the core framework - for building applications, use `composer create-project tempcord/tempcord your-bot-name`.
 
 ## Features
 
-- 🚀 **Modern PHP 8.3+** - Leverages the latest PHP features and syntax
+- 🚀 **Modern PHP 8.5+** - Leverages the latest PHP features and syntax
 - 🎯 **Attribute-Based Commands** - Define Discord commands using PHP attributes
 - 📡 **Event-Driven Architecture** - Handle Discord events with clean, organized handlers
 - 🔧 **Auto-Discovery** - Automatic command and event registration
@@ -30,7 +30,7 @@ The framework leverages PHP 8.3+ features and modern development practices to de
 
 ### Prerequisites
 
-- PHP 8.3 or higher
+- PHP 8.5 or higher
 - Composer
 - A Discord Bot Token (from [Discord Developer Portal](https://discord.com/developers/applications))
 

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "tempcord/framework",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "A modern, elegant PHP framework for building Discord bots with ease",
     "type": "library",
     "require": {
-        "php": "^8.3",
-        "tempest/console": "^1.6",
+        "php": "^8.5",
+        "tempest/console": "^3.18",
         "ragnarok/fenrir": "^1.0",
-        "tempest/core": "^1.6"
+        "tempest/core": "^3.18"
     },
     "license": "MIT",
     "authors": [
@@ -21,13 +21,13 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "^10.0",
-        "phpstan/phpstan": "^1.0",
+        "phpunit/phpunit": "^13.0",
+        "phpstan/phpstan": "^2.1",
         "friendsofphp/php-cs-fixer": "^3.0"
     },
     "scripts": {
         "test": "phpunit",
-        "analyse": "phpstan analyse",
+        "analyse": "phpstan analyse --memory-limit=1G",
         "cs-fix": "php-cs-fixer fix"
     },
     "config": {
@@ -43,6 +43,11 @@
     "autoload": {
         "psr-4": {
             "Tempcord\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tempcord\\Tests\\": "tests/"
         }
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+    level: 5
+    paths:
+        - src
+        - tests
+    excludePaths:
+        - tests/Fixtures

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnWarning="true"
+         failOnNotice="true"
+         failOnDeprecation="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/AllCommandExtension.php
+++ b/src/AllCommandExtension.php
@@ -10,7 +10,6 @@ use Ragnarok\Fenrir\FilteredEventEmitter;
 use Ragnarok\Fenrir\Gateway\Events\InteractionCreate;
 use Ragnarok\Fenrir\Interaction\CommandInteraction;
 use Ragnarok\Fenrir\Parts\ApplicationCommandInteractionDataOptionStructure;
-use function Freezemage\ArrayUtils\find;
 
 final class AllCommandExtension extends \Ragnarok\Fenrir\Command\AllCommandExtension
 {
@@ -78,7 +77,7 @@ final class AllCommandExtension extends \Ragnarok\Fenrir\Command\AllCommandExten
     private function drillName(array $options, array &$names): void
     {
         /** @var ?ApplicationCommandInteractionDataOptionStructure $subCommand */
-        $subCommand = find($options ?? [], function (ApplicationCommandInteractionDataOptionStructure $option) {
+        $subCommand = array_find($options, function (ApplicationCommandInteractionDataOptionStructure $option) {
             return in_array($option->type, [
                 ApplicationCommandOptionType::SUB_COMMAND,
                 ApplicationCommandOptionType::SUB_COMMAND_GROUP,

--- a/src/Attributes/Command.php
+++ b/src/Attributes/Command.php
@@ -89,7 +89,8 @@ final class Command
     /** @var array<SubcommandGroup|Subcommand|Option> */
     public array $options {
         get {
-            $options = $this->getAttribute('options');
+            // A command may legitimately declare no options at all, so start from a list.
+            $options = $this->getAttribute('options') ?? [];
 
             if ($this->reflector->hasAttribute(SubcommandGroup::class)) {
                 /** @var SubcommandGroup $subcommandGroup */
@@ -132,16 +133,23 @@ final class Command
 
     public ClassReflector $reflector;
 
+    /**
+     * The guild this command is scoped to, or null when it is registered globally.
+     */
+    public ?string $guildId;
+
     public function __construct(
         string|BackedEnum|null         $name = null,
         public ?string                 $description = null,
-        public ?int                    $guildId = null,
+        int|string|null                $guildId = null,
         public bool                    $isNsfw = false,
         public array                   $permissions = [],
         public bool                    $directMessage = true,
         public ApplicationCommandTypes $type = ApplicationCommandTypes::CHAT_INPUT
     )
     {
+        $this->guildId = $guildId === null ? null : (string) $guildId;
+
         $this->setAttribute('name', $name);
     }
 

--- a/src/Attributes/Option.php
+++ b/src/Attributes/Option.php
@@ -18,7 +18,7 @@ use Tempcord\Traits\HasAttributes;
 use Tempest\Reflection\ParameterReflector;
 use Throwable;
 use function React\Async\await;
-use function Tempest\get;
+use function Tempest\Container\get;
 use function Tempest\Support\str;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]

--- a/src/Attributes/Subcommand.php
+++ b/src/Attributes/Subcommand.php
@@ -13,7 +13,7 @@ use Tempcord\Traits\HasAttributes;
 use Tempest\Reflection\MethodReflector;
 use function React\Async\async;
 use function React\Async\await;
-use function Tempest\get;
+use function Tempest\Container\get;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 final class Subcommand

--- a/src/Logging/ConsoleLogChannel.php
+++ b/src/Logging/ConsoleLogChannel.php
@@ -6,7 +6,7 @@ use Monolog\Level;
 use Tempcord\Logging\Handlers\ConsoleLogHandler;
 use Tempest\Console\Console;
 use Tempest\Log\LogChannel;
-use function Tempest\get;
+use function Tempest\Container\get;
 
 final class ConsoleLogChannel implements LogChannel
 {

--- a/src/Logging/Handlers/ConsoleLogHandler.php
+++ b/src/Logging/Handlers/ConsoleLogHandler.php
@@ -7,7 +7,7 @@ use Monolog\Level;
 use Monolog\LogRecord;
 use Psr\Log\LogLevel;
 use Tempest\Console\Console;
-use function Tempest\Support\Arr\map_iterable;
+use function Tempest\Support\Arr\map;
 use function Tempest\Support\str;
 
 final class ConsoleLogHandler extends AbstractProcessingHandler
@@ -47,7 +47,7 @@ final class ConsoleLogHandler extends AbstractProcessingHandler
         
         $messageLower = str($message)->lower();
         return $messageLower->contains(
-            map_iterable($this->except, fn(string $pattern) => str($pattern)->lower())
+            map($this->except, fn(string $pattern) => str($pattern)->lower())
         );
     }
     
@@ -59,7 +59,12 @@ final class ConsoleLogHandler extends AbstractProcessingHandler
             $timestamp = $record->datetime->format('Y-m-d H:i:s');
             $message = "[{$timestamp}] {$message}";
         }
-        
+
+        if ($this->includeContext && $record->context !== []) {
+            $context = json_encode($record->context, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR);
+            $message = "{$message} {$context}";
+        }
+
         return $message;
     }
     

--- a/src/Registries/CommandsRegistry.php
+++ b/src/Registries/CommandsRegistry.php
@@ -18,7 +18,6 @@ use Tempest\Console\Console;
 use Tempest\Container\Singleton;
 use Throwable;
 use function React\Async\await;
-use function Tempest\Support\Arr\map_iterable;
 
 #[Singleton]
 final class CommandsRegistry
@@ -32,16 +31,28 @@ final class CommandsRegistry
 
     public function add(Command $command): void
     {
-        if ($command->guildId) {
-            $this->commands[$command->guildId] = $command;
-            return;
+        $key = self::key($command);
+
+        if (array_key_exists($key, $this->commands)) {
+            $command->mergeOptions($this->commands[$key]);
         }
 
-        if (array_key_exists($command->name, $this->commands)) {
-            $command->mergeOptions($this->commands[$command->name]);
-        }
+        $this->commands[$key] = $command;
+    }
 
-        $this->commands[$command->name] = $command;
+    /**
+     * Commands are keyed by name, scoped by guild so that a guild command
+     * neither collides with another command in the same guild nor with the
+     * global command of the same name.
+     *
+     * Discord command names cannot contain ":", so the two key shapes
+     * can never overlap.
+     */
+    private static function key(Command $command): string
+    {
+        return $command->guildId === null
+            ? $command->name
+            : $command->guildId . ':' . $command->name;
     }
 
     /**
@@ -54,23 +65,36 @@ final class CommandsRegistry
             return;
         }
 
-        $register = static fn(string $through, int $applicationId) => static function (Command $command) use ($console, $discord, $applicationId, $through) {
-            try {
-                $command = await($discord->rest->{$through}->createApplicationCommand(
-                    $applicationId,
-                    $command->build
-                ));
-                $console->success('Command "' . $command->name . '" registered.');
-            } catch (Throwable $throwable) {
-                $console->error($throwable->getMessage());
-            }
-        };
-
         try {
             $application = await($discord->rest->application->getCurrent());
-            map_iterable($this->commands, $register('globalCommand', $application->id));
         } catch (Throwable $throwable) {
             $console->error($throwable->getMessage());
+            return;
+        }
+
+        foreach ($this->commands as $command) {
+            try {
+                /*
+                 * Guild commands go to a different endpoint that additionally
+                 * takes the guild id, so the two cannot share a call.
+                 */
+                await($command->guildId === null
+                    ? $discord->rest->globalCommand->createApplicationCommand(
+                        $application->id,
+                        $command->build,
+                    )
+                    : $discord->rest->guildCommand->createApplicationCommand(
+                        $application->id,
+                        $command->guildId,
+                        $command->build,
+                    ));
+
+                $console->success($command->guildId === null
+                    ? 'Command "' . $command->name . '" registered globally.'
+                    : 'Command "' . $command->name . '" registered in guild ' . $command->guildId . '.');
+            } catch (Throwable $throwable) {
+                $console->error('Command "' . $command->name . '": ' . $throwable->getMessage());
+            }
         }
     }
 
@@ -167,7 +191,7 @@ final class CommandsRegistry
                         return $result;
                     }
                 }
-            } else if ((isset($option->focused) && $option->focused === true) && $definition->options[$name]) {
+            } else if ((isset($option->focused) && $option->focused === true) && isset($definition->options[$name])) {
                 return [
                     $definition->options[$name],
                     $option

--- a/src/Registries/EventsRegistry.php
+++ b/src/Registries/EventsRegistry.php
@@ -6,7 +6,7 @@ use Tempcord\Attributes\Event;
 use Tempcord\Tempcord;
 use Tempest\Console\Console;
 use Tempest\Container\Singleton;
-use function Tempest\get;
+use function Tempest\Container\get;
 
 #[Singleton]
 final class EventsRegistry

--- a/src/Tempcord.php
+++ b/src/Tempcord.php
@@ -8,7 +8,7 @@ use Ragnarok\Fenrir\Gateway\Events\Ready;
 use Tempcord\Registries\CommandsRegistry;
 use Tempcord\Registries\EventsRegistry;
 use Tempest\Console\Console;
-use function Tempest\get;
+use function Tempest\Container\get;
 
 final class Tempcord
 {

--- a/tests/Doubles/FakeDiscord.php
+++ b/tests/Doubles/FakeDiscord.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tempcord\Tests\Doubles;
+
+use Psr\Log\NullLogger;
+use Ragnarok\Fenrir\DataMapper;
+use Ragnarok\Fenrir\Discord;
+use Ragnarok\Fenrir\Rest\Rest;
+
+/**
+ * A Discord instance wired to a real Rest over a recording transport, so no
+ * gateway or network is involved.
+ */
+final class FakeDiscord extends Discord
+{
+    public function __construct(public readonly RecordingHttp $http)
+    {
+        $this->rest = new Rest($this->http, new DataMapper(new NullLogger()), new NullLogger());
+    }
+}

--- a/tests/Doubles/RecordingHttp.php
+++ b/tests/Doubles/RecordingHttp.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tempcord\Tests\Doubles;
+
+use Discord\Http\Http;
+use React\Promise\PromiseInterface;
+use RuntimeException;
+use function React\Promise\reject;
+use function React\Promise\resolve;
+
+/**
+ * Stands in for the concrete Http class fenrir's Rest requires, recording every
+ * request so tests can assert which Discord endpoint a command was sent to.
+ */
+final class RecordingHttp extends Http
+{
+    /** @var list<array{url: string, content: mixed}> */
+    public array $posts = [];
+
+    public function __construct(
+        private readonly bool $failApplicationLookup = false,
+        private readonly array $failPostsMatching = [],
+    ) {}
+
+    public function get($url, $content = null, array $headers = []): PromiseInterface
+    {
+        if ($this->failApplicationLookup) {
+            return reject(new RuntimeException('401: Unauthorized'));
+        }
+
+        return resolve((object) [
+            'id' => '424242',
+            'name' => 'test-bot',
+            'description' => '',
+            'icon' => null,
+        ]);
+    }
+
+    public function post($url, $content = null, array $headers = []): PromiseInterface
+    {
+        $url = (string) $url;
+
+        $this->posts[] = ['url' => $url, 'content' => $content];
+
+        foreach ($this->failPostsMatching as $needle) {
+            if (str_contains($url, $needle)) {
+                return reject(new RuntimeException('50035: Invalid Form Body'));
+            }
+        }
+
+        return resolve((object) ['id' => '1', 'name' => 'registered']);
+    }
+
+    /** @return list<string> */
+    public function postedUrls(): array
+    {
+        return array_column($this->posts, 'url');
+    }
+}

--- a/tests/Fixtures/CommandName.php
+++ b/tests/Fixtures/CommandName.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+enum CommandName: string
+{
+    case Weather = 'weather';
+}

--- a/tests/Fixtures/CommandUserSettings.php
+++ b/tests/Fixtures/CommandUserSettings.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+
+#[Command(description: 'Prefix and suffix are both stripped')]
+final class CommandUserSettings
+{
+    public function __invoke(): void {}
+}

--- a/tests/Fixtures/DescriptionlessCommand.php
+++ b/tests/Fixtures/DescriptionlessCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+
+#[Command]
+final class DescriptionlessCommand
+{
+    public function __invoke(): void {}
+}

--- a/tests/Fixtures/EnumNamedCommand.php
+++ b/tests/Fixtures/EnumNamedCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+
+#[Command(name: CommandName::Weather, description: 'Named by a backed enum')]
+final class EnumNamedCommand
+{
+    public function __invoke(): void {}
+}

--- a/tests/Fixtures/GlobalAlphaCommand.php
+++ b/tests/Fixtures/GlobalAlphaCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+
+#[Command(name: 'alpha', description: 'Alpha, registered globally')]
+final class GlobalAlphaCommand
+{
+    public function __invoke(): void {}
+}

--- a/tests/Fixtures/GuildAlphaCommand.php
+++ b/tests/Fixtures/GuildAlphaCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+
+#[Command(name: 'alpha', description: 'Alpha, scoped to guild 111', guildId: 111)]
+final class GuildAlphaCommand
+{
+    public function __invoke(): void {}
+}

--- a/tests/Fixtures/GuildBetaCommand.php
+++ b/tests/Fixtures/GuildBetaCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+
+#[Command(name: 'beta', description: 'Beta, scoped to the same guild 111', guildId: 111)]
+final class GuildBetaCommand
+{
+    public function __invoke(): void {}
+}

--- a/tests/Fixtures/ModerationCommand.php
+++ b/tests/Fixtures/ModerationCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+use Tempcord\Attributes\Option;
+use Tempcord\Attributes\Subcommand;
+
+#[Command(description: 'Moderation tools')]
+final class ModerationCommand
+{
+    #[Subcommand(name: 'kick', description: 'Kick a member')]
+    public function kick(
+        #[Option(description: 'Reason for the kick')] string $reason,
+    ): string {
+        return 'kicked: ' . $reason;
+    }
+}

--- a/tests/Fixtures/MusicCommand.php
+++ b/tests/Fixtures/MusicCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+use Tempcord\Attributes\Option;
+use Tempcord\Attributes\Subcommand;
+use Tempcord\Attributes\SubcommandGroup;
+
+#[Command(description: 'Music controls')]
+#[SubcommandGroup(name: 'playlist', description: 'Playlist controls')]
+final class MusicCommand
+{
+    #[Subcommand(name: 'play', description: 'Play a track')]
+    public function play(
+        #[Option(description: 'Track title')] string $title,
+    ): string {
+        return 'playing ' . $title;
+    }
+
+    #[Subcommand(name: 'stop', description: 'Stop playback')]
+    public function stop(): string
+    {
+        return 'stopped';
+    }
+
+    public function notASubcommand(): void {}
+}

--- a/tests/Fixtures/NamedCommand.php
+++ b/tests/Fixtures/NamedCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+
+#[Command(name: 'explicit', description: 'Has an explicit name')]
+final class NamedCommand
+{
+    public function __invoke(): void {}
+}

--- a/tests/Fixtures/NoHandlerCommand.php
+++ b/tests/Fixtures/NoHandlerCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+
+#[Command(description: 'Declares neither subcommands nor __invoke')]
+final class NoHandlerCommand
+{
+    public function somethingElse(): void {}
+}

--- a/tests/Fixtures/OptionTypesCommand.php
+++ b/tests/Fixtures/OptionTypesCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Ragnarok\Fenrir\Parts\Channel;
+use Ragnarok\Fenrir\Parts\Role;
+use Ragnarok\Fenrir\Parts\User;
+use Tempcord\Attributes\Command;
+use Tempcord\Attributes\Option;
+use Tempcord\Attributes\Subcommand;
+
+#[Command(description: 'Covers every supported option type')]
+final class OptionTypesCommand
+{
+    #[Subcommand(name: 'all', description: 'All supported types')]
+    public function all(
+        #[Option(description: 'a string')] string $text,
+        #[Option(description: 'an int')] int $count,
+        #[Option(description: 'a float')] float $ratio,
+        #[Option(description: 'a bool')] bool $flag,
+        #[Option(description: 'a user')] User $user,
+        #[Option(description: 'a channel')] Channel $channel,
+        #[Option(description: 'a role')] Role $role,
+    ): void {}
+
+    #[Subcommand(name: 'unsupported', description: 'An unsupported type')]
+    public function unsupported(
+        #[Option(description: 'an array')] array $values,
+    ): void {}
+
+    #[Subcommand(name: 'untyped', description: 'An untyped parameter')]
+    public function untyped(
+        #[Option(description: 'no type')] $whatever,
+    ): void {}
+
+    #[Subcommand(name: 'renamed', description: 'Option with an explicit name')]
+    public function renamed(
+        #[Option(description: 'renamed option', name: 'custom')] string $original,
+    ): void {}
+}

--- a/tests/Fixtures/OtherGuildAlphaCommand.php
+++ b/tests/Fixtures/OtherGuildAlphaCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+
+#[Command(name: 'alpha', description: 'Alpha, scoped to a different guild', guildId: 222)]
+final class OtherGuildAlphaCommand
+{
+    public function __invoke(): void {}
+}

--- a/tests/Fixtures/PingCommand.php
+++ b/tests/Fixtures/PingCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Ragnarok\Fenrir\Interaction\CommandInteraction;
+use Tempcord\Attributes\Command;
+use Tempcord\Attributes\Option;
+
+#[Command(description: 'Replies with pong')]
+final class PingCommand
+{
+    public function __invoke(
+        CommandInteraction $interaction,
+        #[Option(description: 'Who to greet')] string $name,
+        #[Option(description: 'How many times')] int $times = 1,
+    ): string {
+        return $name . ':' . $times;
+    }
+}

--- a/tests/Unit/ArrayAutocompleteTest.php
+++ b/tests/Unit/ArrayAutocompleteTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Ragnarok\Fenrir\Interaction\CommandInteraction;
+use Tempcord\AutoCompletes\ArrayAutocomplete;
+
+#[CoversClass(ArrayAutocomplete::class)]
+final class ArrayAutocompleteTest extends TestCase
+{
+    private function interaction(): CommandInteraction
+    {
+        return $this->createStub(CommandInteraction::class);
+    }
+
+    public function test_it_filters_items_by_substring(): void
+    {
+        $autocomplete = new ArrayAutocomplete(['apple', 'banana', 'grape']);
+
+        $this->assertSame([0 => 'apple', 2 => 'grape'], $autocomplete->handle($this->interaction(), 'ap'));
+    }
+
+    public function test_it_reindexes_when_declared_as_a_list(): void
+    {
+        $autocomplete = new ArrayAutocomplete(['apple', 'banana', 'grape'], isList: true);
+
+        $this->assertSame(['apple', 'grape'], $autocomplete->handle($this->interaction(), 'ap'));
+    }
+
+    public function test_it_preserves_keys_of_an_associative_map(): void
+    {
+        $autocomplete = new ArrayAutocomplete(['Apple' => 'apple', 'Banana' => 'banana']);
+
+        $this->assertSame(['Banana' => 'banana'], $autocomplete->handle($this->interaction(), 'nan'));
+    }
+
+    public function test_an_empty_needle_matches_everything(): void
+    {
+        $autocomplete = new ArrayAutocomplete(['apple', 'banana'], isList: true);
+
+        $this->assertSame(['apple', 'banana'], $autocomplete->handle($this->interaction(), ''));
+    }
+
+    public function test_it_returns_nothing_when_no_item_matches(): void
+    {
+        $autocomplete = new ArrayAutocomplete(['apple', 'banana'], isList: true);
+
+        $this->assertSame([], $autocomplete->handle($this->interaction(), 'zzz'));
+    }
+}

--- a/tests/Unit/CommandBuildTest.php
+++ b/tests/Unit/CommandBuildTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Ragnarok\Fenrir\Enums\ApplicationCommandOptionType;
+use RuntimeException;
+use Tempcord\Attributes\Command;
+use Tempcord\Tests\Fixtures\DescriptionlessCommand;
+use Tempcord\Tests\Fixtures\ModerationCommand;
+use Tempcord\Tests\Fixtures\MusicCommand;
+use Tempcord\Tests\Fixtures\NamedCommand;
+use Tempcord\Tests\Fixtures\NoHandlerCommand;
+use Tempcord\Tests\Fixtures\PingCommand;
+
+#[CoversClass(Command::class)]
+final class CommandBuildTest extends TestCase
+{
+    public function test_it_builds_a_chat_input_command(): void
+    {
+        $builder = $this->command(PingCommand::class)->build;
+        $built = $builder->get();
+
+        $this->assertSame('ping', $built['name']);
+        $this->assertSame('Replies with pong', $built['description']);
+        $this->assertFalse($builder->getNsfw());
+        $this->assertTrue($builder->getDmPermission());
+    }
+
+    public function test_a_chat_input_command_requires_a_description(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Description for command [descriptionless] is required when type=CHAT_INPUT');
+
+        $this->command(DescriptionlessCommand::class)->build;
+    }
+
+    public function test_an_invokable_command_exposes_its_invoke_parameters_as_options(): void
+    {
+        $options = $this->command(PingCommand::class)->options;
+
+        $this->assertSame(['name', 'times'], array_keys($options));
+        $this->assertTrue($options['name']->isRequired);
+        $this->assertFalse($options['times']->isRequired);
+    }
+
+    public function test_a_grouped_command_exposes_the_group_as_its_only_option(): void
+    {
+        $options = $this->command(MusicCommand::class)->options;
+
+        $this->assertSame(['playlist'], array_keys($options));
+        $this->assertSame(
+            ApplicationCommandOptionType::SUB_COMMAND_GROUP->value,
+            $options['playlist']->build->get()['type'],
+        );
+    }
+
+    public function test_an_ungrouped_command_exposes_its_subcommands_directly(): void
+    {
+        $options = $this->command(ModerationCommand::class)->options;
+
+        $this->assertSame(['kick'], array_keys($options));
+        $this->assertSame(
+            ApplicationCommandOptionType::SUB_COMMAND->value,
+            $options['kick']->build->get()['type'],
+        );
+    }
+
+    /**
+     * An option-less slash command is perfectly normal and must not blow up
+     * on the way to a builder.
+     */
+    public function test_a_command_without_any_options_builds_cleanly(): void
+    {
+        $command = $this->command(NamedCommand::class);
+
+        $this->assertSame([], $command->options);
+        $this->assertSame('explicit', $command->build->get()['name']);
+    }
+
+    public function test_a_command_with_neither_subcommands_nor_invoke_is_rejected(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('should declare public sub-commands or have an __invoke method');
+
+        $this->command(NoHandlerCommand::class)->options;
+    }
+}

--- a/tests/Unit/CommandNameResolutionTest.php
+++ b/tests/Unit/CommandNameResolutionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Ragnarok\Fenrir\Enums\ApplicationCommandOptionType;
+use Ragnarok\Fenrir\Gateway\Events\InteractionCreate;
+use Ragnarok\Fenrir\Parts\ApplicationCommandInteractionDataOptionStructure;
+use Ragnarok\Fenrir\Parts\InteractionData;
+use Tempcord\AllCommandExtension;
+use ReflectionMethod;
+
+#[CoversClass(AllCommandExtension::class)]
+final class CommandNameResolutionTest extends TestCase
+{
+    private function option(string $name, ApplicationCommandOptionType $type, array $children = []): ApplicationCommandInteractionDataOptionStructure
+    {
+        $option = new ApplicationCommandInteractionDataOptionStructure();
+        $option->name = $name;
+        $option->type = $type;
+        $option->options = $children;
+
+        return $option;
+    }
+
+    private function fullName(InteractionCreate $interaction): string
+    {
+        return new ReflectionMethod(AllCommandExtension::class, 'getFullNameByInteraction')
+            ->invoke(new AllCommandExtension(), $interaction);
+    }
+
+    private function interaction(string $command, array $options): InteractionCreate
+    {
+        $data = new InteractionData();
+        $data->name = $command;
+        $data->options = $options;
+
+        $interaction = new InteractionCreate();
+        $interaction->data = $data;
+
+        return $interaction;
+    }
+
+    public function test_a_plain_command_resolves_to_its_own_name(): void
+    {
+        $interaction = $this->interaction('ping', [
+            $this->option('name', ApplicationCommandOptionType::STRING),
+        ]);
+
+        $this->assertSame('ping', $this->fullName($interaction));
+    }
+
+    public function test_a_subcommand_is_appended_to_the_command_name(): void
+    {
+        $interaction = $this->interaction('moderation', [
+            $this->option('kick', ApplicationCommandOptionType::SUB_COMMAND, [
+                $this->option('reason', ApplicationCommandOptionType::STRING),
+            ]),
+        ]);
+
+        $this->assertSame('moderation.kick', $this->fullName($interaction));
+    }
+
+    public function test_it_drills_through_a_subcommand_group(): void
+    {
+        $interaction = $this->interaction('music', [
+            $this->option('playlist', ApplicationCommandOptionType::SUB_COMMAND_GROUP, [
+                $this->option('play', ApplicationCommandOptionType::SUB_COMMAND, [
+                    $this->option('title', ApplicationCommandOptionType::STRING),
+                ]),
+            ]),
+        ]);
+
+        $this->assertSame('music.playlist.play', $this->fullName($interaction));
+    }
+
+    public function test_a_command_without_options_resolves_to_its_own_name(): void
+    {
+        $interaction = $this->interaction('stop', []);
+
+        $this->assertSame('stop', $this->fullName($interaction));
+    }
+}

--- a/tests/Unit/CommandNameTest.php
+++ b/tests/Unit/CommandNameTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Tempcord\Attributes\Command;
+use Tempcord\Tests\Fixtures\CommandUserSettings;
+use Tempcord\Tests\Fixtures\EnumNamedCommand;
+use Tempcord\Tests\Fixtures\NamedCommand;
+use Tempcord\Tests\Fixtures\PingCommand;
+
+#[CoversClass(Command::class)]
+final class CommandNameTest extends TestCase
+{
+    public function test_it_derives_a_snake_cased_name_from_the_class_name(): void
+    {
+        $this->assertSame('ping', $this->command(PingCommand::class)->name);
+    }
+
+    public function test_it_strips_a_command_prefix_as_well_as_a_suffix(): void
+    {
+        $this->assertSame('user_settings', $this->command(CommandUserSettings::class)->name);
+    }
+
+    public function test_an_explicit_name_wins_over_the_class_name(): void
+    {
+        $this->assertSame('explicit', $this->command(NamedCommand::class)->name);
+    }
+
+    public function test_a_backed_enum_name_is_unwrapped_to_its_value(): void
+    {
+        $this->assertSame('weather', $this->command(EnumNamedCommand::class)->name);
+    }
+}

--- a/tests/Unit/CommandRegistrationTest.php
+++ b/tests/Unit/CommandRegistrationTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionProperty;
+use Tempcord\AllCommandExtension;
+use Tempcord\Registries\CommandsRegistry;
+use Tempcord\Tests\Doubles\FakeDiscord;
+use Tempcord\Tests\Doubles\RecordingHttp;
+use Tempcord\Tests\Fixtures\GlobalAlphaCommand;
+use Tempcord\Tests\Fixtures\GuildAlphaCommand;
+use Tempcord\Tests\Fixtures\GuildBetaCommand;
+use Tempcord\Tests\Fixtures\ModerationCommand;
+use Tempcord\Tests\Fixtures\OtherGuildAlphaCommand;
+use Tempcord\Tests\Fixtures\PingCommand;
+use Tempest\Console\Console;
+
+#[CoversClass(CommandsRegistry::class)]
+final class CommandRegistrationTest extends TestCase
+{
+    private const string GLOBAL_ENDPOINT = 'applications/424242/commands';
+
+    private function guildEndpoint(string $guildId): string
+    {
+        return 'applications/424242/guilds/' . $guildId . '/commands';
+    }
+
+    private function registry(string ...$commandClasses): CommandsRegistry
+    {
+        $registry = new CommandsRegistry(new AllCommandExtension());
+
+        foreach ($commandClasses as $class) {
+            $registry->add($this->command($class));
+        }
+
+        return $registry;
+    }
+
+    /** @return array<string, mixed> */
+    private function storedCommands(CommandsRegistry $registry): array
+    {
+        return new ReflectionProperty(CommandsRegistry::class, 'commands')->getValue($registry);
+    }
+
+    public function test_a_global_command_goes_to_the_global_endpoint(): void
+    {
+        $http = new RecordingHttp();
+
+        $this->registry(PingCommand::class)
+            ->register($this->createStub(Console::class), new FakeDiscord($http));
+
+        $this->assertSame([self::GLOBAL_ENDPOINT], $http->postedUrls());
+    }
+
+    public function test_a_guild_command_goes_to_the_guild_endpoint(): void
+    {
+        $http = new RecordingHttp();
+
+        $this->registry(GuildAlphaCommand::class)
+            ->register($this->createStub(Console::class), new FakeDiscord($http));
+
+        $this->assertSame([$this->guildEndpoint('111')], $http->postedUrls());
+    }
+
+    /**
+     * The original defect: guild commands were keyed by guild id alone, so a
+     * second command in the same guild silently replaced the first.
+     */
+    public function test_two_commands_in_the_same_guild_are_both_registered(): void
+    {
+        $http = new RecordingHttp();
+        $registry = $this->registry(GuildAlphaCommand::class, GuildBetaCommand::class);
+
+        $this->assertCount(2, $this->storedCommands($registry));
+
+        $registry->register($this->createStub(Console::class), new FakeDiscord($http));
+
+        $this->assertSame(
+            [$this->guildEndpoint('111'), $this->guildEndpoint('111')],
+            $http->postedUrls(),
+        );
+    }
+
+    public function test_the_same_command_name_in_two_guilds_is_registered_in_each(): void
+    {
+        $http = new RecordingHttp();
+
+        $this->registry(GuildAlphaCommand::class, OtherGuildAlphaCommand::class)
+            ->register($this->createStub(Console::class), new FakeDiscord($http));
+
+        $this->assertSame(
+            [$this->guildEndpoint('111'), $this->guildEndpoint('222')],
+            $http->postedUrls(),
+        );
+    }
+
+    public function test_a_guild_command_does_not_displace_the_global_command_of_the_same_name(): void
+    {
+        $http = new RecordingHttp();
+
+        $this->registry(GlobalAlphaCommand::class, GuildAlphaCommand::class)
+            ->register($this->createStub(Console::class), new FakeDiscord($http));
+
+        $this->assertSame(
+            [self::GLOBAL_ENDPOINT, $this->guildEndpoint('111')],
+            $http->postedUrls(),
+        );
+    }
+
+    public function test_a_mixed_set_is_routed_per_command(): void
+    {
+        $http = new RecordingHttp();
+
+        $this->registry(PingCommand::class, GuildAlphaCommand::class, ModerationCommand::class)
+            ->register($this->createStub(Console::class), new FakeDiscord($http));
+
+        $this->assertSame(
+            [self::GLOBAL_ENDPOINT, $this->guildEndpoint('111'), self::GLOBAL_ENDPOINT],
+            $http->postedUrls(),
+        );
+    }
+
+    public function test_the_guild_id_is_reported_on_success(): void
+    {
+        $console = $this->createMock(Console::class);
+        $console->expects($this->once())
+            ->method('success')
+            ->with('Command "alpha" registered in guild 111.');
+
+        $this->registry(GuildAlphaCommand::class)->register($console, new FakeDiscord(new RecordingHttp()));
+    }
+
+    public function test_one_failing_command_does_not_stop_the_others(): void
+    {
+        $http = new RecordingHttp(failPostsMatching: ['/guilds/']);
+        $console = $this->createMock(Console::class);
+        $console->expects($this->once())
+            ->method('error')
+            ->with($this->stringContains('Command "alpha"'));
+        $console->expects($this->exactly(2))->method('success');
+
+        $this->registry(PingCommand::class, GuildAlphaCommand::class, ModerationCommand::class)
+            ->register($console, new FakeDiscord($http));
+
+        $this->assertCount(3, $http->postedUrls());
+    }
+
+    public function test_nothing_is_registered_when_the_application_lookup_fails(): void
+    {
+        $http = new RecordingHttp(failApplicationLookup: true);
+        $console = $this->createMock(Console::class);
+        $console->expects($this->once())->method('error');
+        $console->expects($this->never())->method('success');
+
+        $this->registry(PingCommand::class)->register($console, new FakeDiscord($http));
+
+        $this->assertSame([], $http->postedUrls());
+    }
+}

--- a/tests/Unit/CommandsRegistryTest.php
+++ b/tests/Unit/CommandsRegistryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionProperty;
+use Tempcord\AllCommandExtension;
+use Tempcord\Attributes\Command;
+use Tempcord\Registries\CommandsRegistry;
+use Tempcord\Tests\Fixtures\ModerationCommand;
+use Tempcord\Tests\Fixtures\PingCommand;
+use Tempest\Console\Console;
+
+#[CoversClass(CommandsRegistry::class)]
+final class CommandsRegistryTest extends TestCase
+{
+    private function registry(): CommandsRegistry
+    {
+        return new CommandsRegistry(new AllCommandExtension());
+    }
+
+    /**
+     * @return array<string, Command>
+     */
+    private function storedCommands(CommandsRegistry $registry): array
+    {
+        return new ReflectionProperty(CommandsRegistry::class, 'commands')->getValue($registry);
+    }
+
+    public function test_it_stores_a_global_command_under_its_name(): void
+    {
+        $registry = $this->registry();
+        $registry->add($this->command(PingCommand::class));
+
+        $this->assertSame(['ping'], array_keys($this->storedCommands($registry)));
+    }
+
+    public function test_it_keeps_distinct_commands_side_by_side(): void
+    {
+        $registry = $this->registry();
+        $registry->add($this->command(PingCommand::class));
+        $registry->add($this->command(ModerationCommand::class));
+
+        $this->assertSame(['ping', 'moderation'], array_keys($this->storedCommands($registry)));
+    }
+
+    public function test_re_adding_the_same_command_name_merges_the_options(): void
+    {
+        $registry = $this->registry();
+        $registry->add($this->command(PingCommand::class));
+        $registry->add($this->command(PingCommand::class));
+
+        $stored = $this->storedCommands($registry);
+
+        $this->assertCount(1, $stored);
+        $this->assertSame(['name', 'times'], array_keys($stored['ping']->options));
+    }
+
+    public function test_register_warns_instead_of_calling_discord_when_there_is_nothing_to_register(): void
+    {
+        $console = $this->createMock(Console::class);
+        $console->expects($this->once())
+            ->method('warning')
+            ->with('No commands to register.');
+
+        // A null Discord would fatal if it were touched; it never should be.
+        $this->registry()->register($console, $this->createStub(\Ragnarok\Fenrir\Discord::class));
+    }
+}

--- a/tests/Unit/ConsoleLogHandlerTest.php
+++ b/tests/Unit/ConsoleLogHandlerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use DateTimeImmutable;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Tempcord\Logging\Handlers\ConsoleLogHandler;
+use Tempest\Console\Console;
+
+#[CoversClass(ConsoleLogHandler::class)]
+final class ConsoleLogHandlerTest extends TestCase
+{
+    private function record(string $message, array $context = [], Level $level = Level::Info): LogRecord
+    {
+        return new LogRecord(
+            datetime: new DateTimeImmutable('2026-01-02 03:04:05'),
+            channel: 'tempcord',
+            level: $level,
+            message: $message,
+            context: $context,
+        );
+    }
+
+    public function test_it_prefixes_the_timestamp_when_asked(): void
+    {
+        $console = $this->createMock(Console::class);
+        $console->expects($this->once())
+            ->method('info')
+            ->with('[2026-01-02 03:04:05] Connected');
+
+        new ConsoleLogHandler($console, includeContext: false)->handle($this->record('connected'));
+    }
+
+    public function test_it_omits_the_timestamp_when_disabled(): void
+    {
+        $console = $this->createMock(Console::class);
+        $console->expects($this->once())
+            ->method('info')
+            ->with('Connected');
+
+        new ConsoleLogHandler($console, includeTimestamp: false, includeContext: false)
+            ->handle($this->record('connected'));
+    }
+
+    public function test_it_appends_the_record_context(): void
+    {
+        $console = $this->createMock(Console::class);
+        $console->expects($this->once())
+            ->method('info')
+            ->with('Connected {"guild_id":"123","shard":0}');
+
+        new ConsoleLogHandler($console, includeTimestamp: false)
+            ->handle($this->record('connected', ['guild_id' => '123', 'shard' => 0]));
+    }
+
+    public function test_it_appends_nothing_for_an_empty_context(): void
+    {
+        $console = $this->createMock(Console::class);
+        $console->expects($this->once())
+            ->method('info')
+            ->with('Connected');
+
+        new ConsoleLogHandler($console, includeTimestamp: false)->handle($this->record('connected'));
+    }
+
+    public function test_context_can_be_switched_off(): void
+    {
+        $console = $this->createMock(Console::class);
+        $console->expects($this->once())
+            ->method('info')
+            ->with('Connected');
+
+        new ConsoleLogHandler($console, includeTimestamp: false, includeContext: false)
+            ->handle($this->record('connected', ['guild_id' => '123']));
+    }
+
+    public function test_it_skips_messages_matching_an_except_pattern(): void
+    {
+        $console = $this->createMock(Console::class);
+        $console->expects($this->never())->method('info');
+
+        new ConsoleLogHandler($console, except: ['sending heartbeat'])
+            ->handle($this->record('Sending heartbeat now'));
+    }
+
+    public function test_it_routes_by_severity(): void
+    {
+        $console = $this->createMock(Console::class);
+        $console->expects($this->once())->method('error')->with('Boom');
+        $console->expects($this->once())->method('warning')->with('Careful');
+
+        $handler = new ConsoleLogHandler($console, includeTimestamp: false, includeContext: false);
+        $handler->handle($this->record('boom', level: Level::Error));
+        $handler->handle($this->record('careful', level: Level::Warning));
+    }
+}

--- a/tests/Unit/DiscoveryTest.php
+++ b/tests/Unit/DiscoveryTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionProperty;
+use Tempcord\AllCommandExtension;
+use Tempcord\Discoveries\CommandsDiscovery;
+use Tempcord\Registries\CommandsRegistry;
+use Tempcord\Tests\Fixtures\ModerationCommand;
+use Tempcord\Tests\Fixtures\NoHandlerCommand;
+use Tempcord\Tests\Fixtures\PingCommand;
+use Tempest\Discovery\DiscoveryItems;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Reflection\ClassReflector;
+
+#[CoversClass(CommandsDiscovery::class)]
+final class DiscoveryTest extends TestCase
+{
+    private DiscoveryLocation $location;
+
+    protected function setUp(): void
+    {
+        $this->location = new DiscoveryLocation(
+            namespace: 'Tempcord\\Tests\\Fixtures\\',
+            path: __DIR__ . '/../Fixtures',
+        );
+    }
+
+    private function discovery(CommandsRegistry $registry): CommandsDiscovery
+    {
+        $discovery = new CommandsDiscovery($registry);
+        $discovery->setItems(new DiscoveryItems());
+
+        return $discovery;
+    }
+
+    public function test_it_discovers_command_classes_and_feeds_them_to_the_registry(): void
+    {
+        $registry = new CommandsRegistry(new AllCommandExtension());
+        $discovery = $this->discovery($registry);
+
+        $discovery->discover($this->location, new ClassReflector(PingCommand::class));
+        $discovery->discover($this->location, new ClassReflector(ModerationCommand::class));
+        $discovery->apply();
+
+        $stored = new ReflectionProperty(CommandsRegistry::class, 'commands')->getValue($registry);
+
+        $this->assertSame(['ping', 'moderation'], array_keys($stored));
+    }
+
+    public function test_it_attaches_the_class_reflector_to_the_discovered_attribute(): void
+    {
+        $discovery = $this->discovery(new CommandsRegistry(new AllCommandExtension()));
+        $discovery->discover($this->location, new ClassReflector(PingCommand::class));
+
+        $items = iterator_to_array($discovery->getItems());
+
+        $this->assertCount(1, $items);
+        $this->assertSame(PingCommand::class, $items[0]->reflector->getName());
+    }
+
+    public function test_it_ignores_classes_without_the_command_attribute(): void
+    {
+        $discovery = $this->discovery(new CommandsRegistry(new AllCommandExtension()));
+        $discovery->discover($this->location, new ClassReflector(NoHandlerCommand::class));
+        $discovery->discover($this->location, new ClassReflector(DiscoveryTest::class));
+
+        $this->assertCount(1, iterator_to_array($discovery->getItems()));
+    }
+}

--- a/tests/Unit/FocusedOptionTest.php
+++ b/tests/Unit/FocusedOptionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Ragnarok\Fenrir\Enums\ApplicationCommandOptionType;
+use Ragnarok\Fenrir\Parts\ApplicationCommandInteractionDataOptionStructure;
+use ReflectionMethod;
+use Tempcord\AllCommandExtension;
+use Tempcord\Attributes\Command;
+use Tempcord\Registries\CommandsRegistry;
+use Tempcord\Tests\Fixtures\PingCommand;
+
+#[CoversClass(CommandsRegistry::class)]
+final class FocusedOptionTest extends TestCase
+{
+    private function option(string $name, bool $focused = false): ApplicationCommandInteractionDataOptionStructure
+    {
+        $option = new ApplicationCommandInteractionDataOptionStructure();
+        $option->name = $name;
+        $option->type = ApplicationCommandOptionType::STRING;
+        $option->value = 'whatever';
+        $option->options = [];
+        $option->focused = $focused;
+
+        return $option;
+    }
+
+    private function resolve(array $interactionOptions, Command $definition): ?array
+    {
+        return new ReflectionMethod(CommandsRegistry::class, 'resolveFocusedAndParam')
+            ->invoke(new CommandsRegistry(new AllCommandExtension()), $interactionOptions, $definition);
+    }
+
+    public function test_it_resolves_the_focused_option_against_the_definition(): void
+    {
+        $command = $this->command(PingCommand::class);
+        $focused = $this->option('name', focused: true);
+
+        $resolved = $this->resolve([$this->option('times'), $focused], $command);
+
+        $this->assertNotNull($resolved);
+        $this->assertSame($command->options['name'], $resolved[0]);
+        $this->assertSame($focused, $resolved[1]);
+    }
+
+    public function test_it_returns_null_when_nothing_is_focused(): void
+    {
+        $this->assertNull(
+            $this->resolve([$this->option('name'), $this->option('times')], $this->command(PingCommand::class)),
+        );
+    }
+
+    /**
+     * A focused option the command does not declare must not raise an
+     * "Undefined array key" warning — it simply does not resolve.
+     */
+    public function test_a_focused_option_unknown_to_the_definition_resolves_to_null(): void
+    {
+        $this->assertNull(
+            $this->resolve([$this->option('not_declared', focused: true)], $this->command(PingCommand::class)),
+        );
+    }
+
+    public function test_it_returns_null_for_no_options_at_all(): void
+    {
+        $this->assertNull($this->resolve([], $this->command(PingCommand::class)));
+    }
+}

--- a/tests/Unit/InteractionCallbackBuilderTest.php
+++ b/tests/Unit/InteractionCallbackBuilderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Ragnarok\Fenrir\Enums\InteractionCallbackType;
+use Ragnarok\Fenrir\Parts\ApplicationCommandOptionChoice;
+use Tempcord\InteractionCallbackBuilder;
+
+#[CoversClass(InteractionCallbackBuilder::class)]
+final class InteractionCallbackBuilderTest extends TestCase
+{
+    private function choice(string $name, string $value): ApplicationCommandOptionChoice
+    {
+        $choice = new ApplicationCommandOptionChoice();
+        $choice->name = $name;
+        $choice->value = $value;
+
+        return $choice;
+    }
+
+    public function test_it_omits_the_choices_key_when_none_were_set(): void
+    {
+        $data = InteractionCallbackBuilder::new()
+            ->setType(InteractionCallbackType::APPLICATION_COMMAND_AUTOCOMPLETE_RESULT)
+            ->get();
+
+        $this->assertArrayNotHasKey('choices', $data['data'] ?? []);
+    }
+
+    public function test_it_adds_choices_to_the_callback_payload(): void
+    {
+        $choices = [$this->choice('Apple', 'apple')];
+
+        $data = InteractionCallbackBuilder::new()
+            ->setChoices($choices)
+            ->setType(InteractionCallbackType::APPLICATION_COMMAND_AUTOCOMPLETE_RESULT)
+            ->get();
+
+        $this->assertSame(InteractionCallbackType::APPLICATION_COMMAND_AUTOCOMPLETE_RESULT->value, $data['type']);
+        $this->assertSame($choices, $data['data']['choices']);
+    }
+
+    public function test_set_choices_is_fluent_and_replaces_previous_choices(): void
+    {
+        $builder = InteractionCallbackBuilder::new();
+        $builder->setType(InteractionCallbackType::APPLICATION_COMMAND_AUTOCOMPLETE_RESULT);
+
+        $second = [$this->choice('Banana', 'banana')];
+
+        $this->assertSame($builder, $builder->setChoices([$this->choice('Apple', 'apple')]));
+        $this->assertSame($second, $builder->setChoices($second)->get()['data']['choices']);
+    }
+}

--- a/tests/Unit/OptionTest.php
+++ b/tests/Unit/OptionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Ragnarok\Fenrir\Enums\ApplicationCommandOptionType;
+use Tempcord\Attributes\Option;
+use Tempcord\Attributes\Subcommand;
+use Tempcord\Tests\Fixtures\OptionTypesCommand;
+use Tempest\Reflection\ClassReflector;
+
+#[CoversClass(Option::class)]
+final class OptionTest extends TestCase
+{
+    /**
+     * @return array<string, Option>
+     */
+    private function optionsOf(string $method): array
+    {
+        $reflector = new ClassReflector(OptionTypesCommand::class)->getMethod($method);
+
+        /** @var Subcommand $subcommand */
+        $subcommand = $reflector->getAttribute(Subcommand::class);
+        $subcommand->reflector = $reflector;
+
+        return $subcommand->options;
+    }
+
+    public static function supportedTypes(): array
+    {
+        return [
+            'string'  => ['text', ApplicationCommandOptionType::STRING],
+            'int'     => ['count', ApplicationCommandOptionType::INTEGER],
+            'float'   => ['ratio', ApplicationCommandOptionType::NUMBER],
+            'bool'    => ['flag', ApplicationCommandOptionType::BOOLEAN],
+            'User'    => ['user', ApplicationCommandOptionType::USER],
+            'Channel' => ['channel', ApplicationCommandOptionType::CHANNEL],
+            'Role'    => ['role', ApplicationCommandOptionType::ROLE],
+        ];
+    }
+
+    #[DataProvider('supportedTypes')]
+    public function test_it_maps_php_types_to_discord_option_types(string $parameter, ApplicationCommandOptionType $expected): void
+    {
+        $this->assertSame($expected, $this->optionsOf('all')[$parameter]->type);
+    }
+
+    public function test_it_rejects_an_unsupported_type(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Command option type not supported');
+
+        $this->optionsOf('unsupported')['values']->type;
+    }
+
+    public function test_it_rejects_an_untyped_parameter(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Command option does not have type');
+
+        $this->optionsOf('untyped')['whatever']->type;
+    }
+
+    public function test_the_name_defaults_to_the_parameter_name(): void
+    {
+        $this->assertSame('text', $this->optionsOf('all')['text']->name);
+    }
+
+    public function test_an_explicit_name_wins_over_the_parameter_name(): void
+    {
+        $this->assertSame('custom', $this->optionsOf('renamed')['original']->name);
+    }
+
+    public function test_a_parameter_without_a_default_is_required(): void
+    {
+        $this->assertTrue($this->optionsOf('all')['text']->isRequired);
+    }
+
+    public function test_it_builds_a_command_option(): void
+    {
+        $built = $this->optionsOf('all')['count']->build->get();
+
+        $this->assertSame('count', $built['name']);
+        $this->assertSame('an int', $built['description']);
+        $this->assertTrue($built['required']);
+        $this->assertSame(ApplicationCommandOptionType::INTEGER->value, $built['type']);
+        $this->assertFalse($built['autocomplete']);
+    }
+}

--- a/tests/Unit/SubcommandTest.php
+++ b/tests/Unit/SubcommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Ragnarok\Fenrir\Enums\ApplicationCommandOptionType;
+use Tempcord\Attributes\Subcommand;
+use Tempcord\Attributes\SubcommandGroup;
+use Tempcord\Tests\Fixtures\MusicCommand;
+use Tempest\Reflection\ClassReflector;
+
+#[CoversClass(Subcommand::class)]
+#[CoversClass(SubcommandGroup::class)]
+final class SubcommandTest extends TestCase
+{
+    private function group(): SubcommandGroup
+    {
+        $reflector = new ClassReflector(MusicCommand::class);
+
+        /** @var SubcommandGroup $group */
+        $group = $reflector->getAttribute(SubcommandGroup::class);
+        $group->reflector = $reflector;
+
+        return $group;
+    }
+
+    public function test_a_group_collects_only_annotated_methods(): void
+    {
+        $this->assertSame(['play', 'stop'], array_keys($this->group()->options));
+    }
+
+    public function test_a_group_builds_a_sub_command_group_option(): void
+    {
+        $built = $this->group()->build->get();
+
+        $this->assertSame('playlist', $built['name']);
+        $this->assertSame('Playlist controls', $built['description']);
+        $this->assertSame(ApplicationCommandOptionType::SUB_COMMAND_GROUP->value, $built['type']);
+        $this->assertCount(2, $built['options']);
+    }
+
+    public function test_a_subcommand_builds_a_sub_command_option_carrying_its_own_options(): void
+    {
+        $built = $this->group()->options['play']->build->get();
+
+        $this->assertSame('play', $built['name']);
+        $this->assertSame(ApplicationCommandOptionType::SUB_COMMAND->value, $built['type']);
+        $this->assertCount(1, $built['options']);
+        $this->assertSame('title', $built['options'][0]['name']);
+    }
+
+    public function test_a_subcommand_without_parameters_has_no_options(): void
+    {
+        $this->assertSame([], $this->group()->options['stop']->options);
+    }
+
+    public function test_invoke_named_args_reorders_arguments_to_the_signature(): void
+    {
+        $result = $this->group()->options['play']->invokeNamedArgs(
+            new MusicCommand(),
+            ['unused' => 'ignored', 'title' => 'Bohemian Rhapsody'],
+        );
+
+        $this->assertSame('playing Bohemian Rhapsody', $result);
+    }
+
+    public function test_invoke_named_args_rejects_a_missing_required_argument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required parameter: title');
+
+        $this->group()->options['play']->invokeNamedArgs(new MusicCommand(), []);
+    }
+}

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tempcord\Tests\Unit;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use Tempcord\Attributes\Command;
+use Tempest\Reflection\ClassReflector;
+
+abstract class TestCase extends BaseTestCase
+{
+    /**
+     * Resolves the #[Command] attribute off a fixture class the same way
+     * CommandsDiscovery does: read the attribute, then attach the reflector.
+     */
+    protected function command(string $class): Command
+    {
+        $reflector = new ClassReflector($class);
+
+        /** @var Command $command */
+        $command = $reflector->getAttribute(Command::class);
+        $command->reflector = $reflector;
+
+        return $command;
+    }
+}


### PR DESCRIPTION
Bumps the framework to **Tempest 3.18** and **PHP 8.5**, adds the first test suite, and repairs several latent bugs surfaced along the way.

Version: `0.5.0` → `0.6.0`.

**Status:** 69 tests / 111 assertions passing, PHPStan level 5 clean, verified from a clean `composer install`.

## Dependencies

| Package | Before | After |
|---|---|---|
| tempest/core, tempest/console | 1.6 | 3.18 |
| phpunit/phpunit | 10.5 | 13.3 |
| phpstan/phpstan | 1.12 | 2.1 |
| php | `^8.3` | `^8.5` |

The PHP bump isn't cosmetic: both `tempest/core` 3.18 and `ragnarok/fenrir` 1.2 require `^8.5`, so the old `^8.3` constraint could never resolve to them.

## Tempest 3 migration

- `Tempest\get()` → `Tempest\Container\get()`
- `Arr\map_iterable()` → `Arr\map()`

Both confirmed against the official [Tempest 3.0 release notes](https://tempestphp.com/blog/tempest-3). Class loading alone did **not** catch these — PHP resolves functions at call time, so every command and event dispatch would have fataled at runtime.

Tempest 3's other breaking changes (exception handling, session/CSRF, `view()` namespace, `Environment` injection, event-bus enums, `LogConfig`/`DatabaseConfig`) touch subsystems this framework doesn't use, as do all of v2's. Since PHPStan can't see dynamic calls like `$discord->rest->{$through}`, coverage was confirmed with a reflection check over every Tempest symbol the code touches — 10 types, ~40 methods, 4 functions, 6 attributes — plus signature checks on `Discovery::discover`, `DiscoveryItems::add`, `Initializer::initialize` and `Container::get`. All present and compatible.

## Bug fixes

**Guild command registration was broken two ways.**

1. `add()` keyed guild commands by `guildId` alone, so a second command in the same guild silently replaced the first — a guild could only ever hold one command. Now keyed `"{guildId}:{name}"`, with global commands staying on `"{name}"`. Discord command names can't contain `:`, so the shapes can't collide. Guild commands also now get the `mergeOptions` treatment global ones always had.
2. `register()` sent everything through `globalCommand`, so guild-scoped commands were registered globally. This wasn't a one-line oversight — `guildCommand::createApplicationCommand` takes `(appId, guildId, builder)` vs global's `(appId, builder)`, so the dynamic `$discord->rest->{$through}` closure *structurally could not* call it. Replaced with an explicit branch.

**Other fixes**

- `AllCommandExtension` imported `Freezemage\ArrayUtils\find()` — a package neither installed nor declared anywhere. Any subcommand interaction fataled on an undefined function. Replaced with native `array_find()`.
- `Command::$options` returned `null` when `__invoke` declared no `#[Option]` parameters, so any option-less slash command (`/ping`) threw a `TypeError`. The `set` hook already guarded with `?? []`; the getter didn't.
- `register()` typed `$applicationId` as `int`, but `Application::$id` is a `string` and `createApplicationCommand()` expects one. It survived only via weak-mode coercion.
- `resolveFocusedAndParam()` read an array key without `isset()`, warning on any focused option the command doesn't declare.
- `ConsoleLogHandler::$includeContext` was never read; implemented alongside the existing `includeTimestamp`.

## Behaviour changes for consumers

Worth calling out even though this is a `0.x` minor:

- **`Command::$guildId` is now `?string`** rather than `?int` (snowflakes are strings, matching the `applicationId` fix). The constructor still accepts `int|string`, so existing `#[Command(guildId: 123)]` usage is unaffected — only code *reading* the property sees the change.
- **`ConsoleLogHandler` now appends record context by default.** Pass `includeContext: false` for the previous output.
- Consumers must be on PHP 8.5 and Tempest 3.

## Testing

`phpunit.xml` + `tests/`, covering name derivation, PHP→Discord option type mapping, command/subcommand/group builders, `invokeNamedArgs`, autocomplete filtering, the callback builder, the registry, discovery, log handling, and command registration.

Registration is tested against a **real fenrir `Rest` over a recording `Http` double**, asserting actual endpoint URLs (`applications/{app}/commands` vs `applications/{app}/guilds/{guild}/commands`) — behaviour, not implementation.

Each fix was verified to have teeth by reverting it in isolation and confirming the relevant test fails.

## Notes for review

- PHPStan runs at level 5 (clean). Level 6 reports ~30 missing generic/iterable annotations — a separate documentation pass, not upgrade fallout.
- `composer analyse` carries `--memory-limit=1G`; PHPStan 2 crashes at the default 128M on this dependency tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
