### PR TITLE
ci: run tests and static analysis, and release from conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  # Composer bumps arrive as their own pull request, so a dependency moving is
+  # a release of its own rather than something folded into unrelated work.
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: PR Title
+
+# Merges are squashed with the pull request title as the commit subject, so the
+# title is what semantic-release will read. Checking it here is the difference
+# between a release that happens and one that silently does not.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+[^.]$
+          subjectPatternError: |
+            The subject "{subject}" should start lower case and not end with a period.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+# Every merge to master is a candidate. semantic-release reads the commit
+# subjects since the last tag and decides whether there is anything to cut —
+# a docs or chore change releases nothing at all.
+on:
+  push:
+    branches: [master]
+
+# The tag, the GitHub release, and the CHANGELOG commit all need writing.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Tags are how semantic-release knows the current version, so the
+          # whole history has to be there.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/changelog@6
+            @semantic-release/git@10
+            conventional-changelog-conventionalcommits@8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,23 @@
+name: Static Analysis
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.5
+
+      - name: Install packages
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPStan
+        run: composer analyse

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.5', '8.6']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install packages
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run tests
+        run: composer test

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,32 @@
+{
+    "branches": ["master"],
+    "tagFormat": "v${version}",
+    "plugins": [
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "preset": "conventionalcommits"
+            }
+        ],
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                "preset": "conventionalcommits"
+            }
+        ],
+        [
+            "@semantic-release/changelog",
+            {
+                "changelogFile": "CHANGELOG.md"
+            }
+        ],
+        "@semantic-release/github",
+        [
+            "@semantic-release/git",
+            {
+                "assets": ["CHANGELOG.md"],
+                "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+            }
+        ]
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,368 +1,48 @@
-# Contributing to Tempcord
+# Contributing
 
-Thank you for considering contributing to Tempcord! We welcome contributions from everyone and are grateful for every contribution, no matter how small.
+## Commit messages decide releases
 
-## Table of Contents
+Merges are squashed, and the pull request title becomes the commit subject on
+`master`. That subject is read by semantic-release, which cuts the tag and the
+GitHub release — so the title is not a formality, it is the version bump.
 
-- [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
-- [How to Contribute](#how-to-contribute)
-- [Development Setup](#development-setup)
-- [Coding Standards](#coding-standards)
-- [Testing](#testing)
-- [Pull Request Process](#pull-request-process)
-- [Reporting Issues](#reporting-issues)
-- [Feature Requests](#feature-requests)
+Titles follow [Conventional Commits](https://www.conventionalcommits.org):
 
-## Code of Conduct
-
-This project and everyone participating in it is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
-
-## Getting Started
-
-### Prerequisites
-
-- PHP 8.2 or higher
-- Composer
-- Git
-- A Discord application and bot token for testing
-
-### Development Setup
-
-1. **Fork the repository**
-   ```bash
-   # Click the "Fork" button on GitHub, then clone your fork
-   git clone https://github.com/your-username/tempcord.git
-   cd tempcord
-   ```
-
-2. **Install dependencies**
-   ```bash
-   composer install
-   ```
-
-3. **Set up environment**
-   ```bash
-   cp .env.example .env
-   # Edit .env with your Discord bot credentials
-   ```
-
-4. **Run tests to ensure everything works**
-   ```bash
-   composer test
-   ```
-
-## How to Contribute
-
-### Types of Contributions
-
-We welcome several types of contributions:
-
-- **Bug fixes**: Help us squash bugs!
-- **Feature development**: Add new functionality
-- **Documentation**: Improve our docs
-- **Testing**: Add or improve tests
-- **Code quality**: Refactoring, performance improvements
-- **Examples**: Add usage examples or tutorials
-
-### Before You Start
-
-1. **Check existing issues**: Look for existing issues or discussions about your idea
-2. **Create an issue**: For significant changes, create an issue first to discuss the approach
-3. **Small changes**: For small bug fixes or improvements, you can directly create a PR
-
-## Development Workflow
-
-### Branch Naming
-
-Use descriptive branch names:
-- `feature/add-slash-commands`
-- `bugfix/fix-memory-leak`
-- `docs/update-installation-guide`
-- `refactor/improve-event-handling`
-
-### Commit Messages
-
-Follow conventional commit format:
 ```
-type(scope): description
-
-[optional body]
-
-[optional footer]
+feat(components): route buttons and select menus by custom id
+fix(events): contain a listener that throws
+docs(cache): explain what a miss means
 ```
 
-Types:
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, etc.)
-- `refactor`: Code refactoring
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks
+| Prefix | Release |
+| --- | --- |
+| `fix`, `perf` | patch — `1.2.3` → `1.2.4` |
+| `feat` | minor — `1.2.3` → `1.3.0` |
+| `feat!`, or `BREAKING CHANGE:` in the body | major — `1.2.3` → `2.0.0` |
+| `docs`, `test`, `refactor`, `build`, `ci`, `chore` | none |
 
-Examples:
+A pull request whose title does not parse is rejected by a check before it can
+be merged, because a subject semantic-release cannot read is a release that
+silently never happens.
+
+Put the reasoning in the pull request body. It becomes the commit body, and it
+is the part someone reads in a year when they are trying to work out why.
+
+## Breaking changes
+
+Mark them, and say what to do instead:
+
 ```
-feat(commands): add support for slash command options
-fix(events): resolve memory leak in event listener
-docs(readme): update installation instructions
+feat(autocomplete)!: take a class name rather than an instance
+
+BREAKING CHANGE: #[Option(autocomplete: new Foo())] still works, but a
+class name is now built by the container and is the documented form.
 ```
 
-## Coding Standards
-
-### PHP Standards
-
-- Follow [PSR-12](https://www.php-fig.org/psr/psr-12/) coding standard
-- Use strict types: `declare(strict_types=1);`
-- Add type hints for all parameters and return types
-- Use meaningful variable and method names
-- Write self-documenting code with clear comments when necessary
-
-### Code Style
-
-We use PHP CS Fixer to maintain consistent code style:
+## Before opening a pull request
 
 ```bash
-# Check code style
-composer format:check
-
-# Fix code style issues
-composer format
+composer test     # PHPUnit
+composer analyse  # PHPStan
+composer docs     # regenerate docs/ — the suite fails if they drift
 ```
-
-### Static Analysis
-
-We use PHPStan and Psalm for static analysis:
-
-```bash
-# Run PHPStan
-composer analyse
-
-# Run Psalm
-composer psalm
-```
-
-## Testing
-
-### Writing Tests
-
-- Write tests for all new functionality
-- Maintain or improve test coverage
-- Use descriptive test method names
-- Follow the AAA pattern (Arrange, Act, Assert)
-
-### Test Structure
-
-```php
-<?php
-
-namespace Tests\Unit;
-
-use PHPUnit\Framework\TestCase;
-use Tempcord\YourClass;
-
-class YourClassTest extends TestCase
-{
-    public function test_it_does_something_expected(): void
-    {
-        // Arrange
-        $instance = new YourClass();
-        
-        // Act
-        $result = $instance->doSomething();
-        
-        // Assert
-        $this->assertEquals('expected', $result);
-    }
-}
-```
-
-### Running Tests
-
-```bash
-# Run all tests
-composer test
-
-# Run tests with coverage
-composer test:coverage
-
-# Run specific test file
-vendor/bin/phpunit tests/Unit/YourClassTest.php
-
-# Run tests matching a pattern
-vendor/bin/phpunit --filter="test_it_does_something"
-```
-
-## Pull Request Process
-
-### Before Submitting
-
-1. **Update your branch**
-   ```bash
-   git checkout main
-   git pull upstream main
-   git checkout your-feature-branch
-   git rebase main
-   ```
-
-2. **Run the full test suite**
-   ```bash
-   composer test
-   composer analyse
-   composer format:check
-   ```
-
-3. **Update documentation** if needed
-
-### PR Guidelines
-
-1. **Clear title and description**: Explain what your PR does and why
-2. **Link related issues**: Use "Fixes #123" or "Closes #123"
-3. **Small, focused changes**: Keep PRs focused on a single concern
-4. **Add tests**: Include tests for new functionality
-5. **Update docs**: Update relevant documentation
-
-### PR Template
-
-```markdown
-## Description
-Brief description of changes
-
-## Type of Change
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation update
-
-## Testing
-- [ ] Tests pass locally
-- [ ] Added tests for new functionality
-- [ ] Manual testing completed
-
-## Checklist
-- [ ] Code follows project style guidelines
-- [ ] Self-review completed
-- [ ] Documentation updated
-- [ ] No breaking changes (or clearly documented)
-```
-
-## Reporting Issues
-
-### Bug Reports
-
-When reporting bugs, please include:
-
-1. **Clear title**: Summarize the issue
-2. **Environment details**: PHP version, OS, Tempcord version
-3. **Steps to reproduce**: Detailed steps to reproduce the issue
-4. **Expected behavior**: What should happen
-5. **Actual behavior**: What actually happens
-6. **Code samples**: Minimal code to reproduce the issue
-7. **Error messages**: Full error messages and stack traces
-
-### Bug Report Template
-
-```markdown
-**Environment:**
-- PHP Version: 8.2.x
-- Tempcord Version: x.x.x
-- OS: macOS/Linux/Windows
-
-**Description:**
-A clear description of the bug.
-
-**Steps to Reproduce:**
-1. Step one
-2. Step two
-3. Step three
-
-**Expected Behavior:**
-What should happen
-
-**Actual Behavior:**
-What actually happens
-
-**Code Sample:**
-```php
-// Minimal code to reproduce
-```
-
-**Error Messages:**
-```
-Full error message and stack trace
-```
-
-## Feature Requests
-
-For feature requests, please:
-
-1. **Check existing issues**: Ensure the feature hasn't been requested
-2. **Describe the problem**: What problem does this solve?
-3. **Propose a solution**: How should it work?
-4. **Consider alternatives**: What other approaches could work?
-5. **Provide examples**: Show how it would be used
-
-## Documentation
-
-### Writing Documentation
-
-- Use clear, concise language
-- Include code examples
-- Test all code examples
-- Follow existing documentation style
-- Update table of contents if needed
-
-### Documentation Structure
-
-```
-docs/
-├── getting-started.md
-├── commands.md
-├── events.md
-├── middleware.md
-├── configuration.md
-└── api-reference.md
-```
-
-## Community
-
-### Getting Help
-
-- **GitHub Discussions**: For questions and general discussion
-- **Issues**: For bug reports and feature requests
-- **Discord**: Join our community Discord server
-
-### Recognition
-
-We recognize contributors in several ways:
-- Contributors list in README
-- Release notes mention significant contributions
-- Special recognition for major contributions
-
-## Release Process
-
-### Versioning
-
-We follow [Semantic Versioning](https://semver.org/):
-- **MAJOR**: Breaking changes
-- **MINOR**: New features (backward compatible)
-- **PATCH**: Bug fixes (backward compatible)
-
-### Release Checklist
-
-1. Update CHANGELOG.md
-2. Update version in composer.json
-3. Create release tag
-4. Update documentation
-5. Announce release
-
-## Questions?
-
-If you have questions about contributing, please:
-
-1. Check this document first
-2. Search existing issues and discussions
-3. Create a new discussion or issue
-4. Reach out on Discord
-
-Thank you for contributing to Tempcord! 🎉


### PR DESCRIPTION
This repository has **no workflows at all**. Nothing runs on a pull request, so everything merged so far — including [#9](https://github.com/Tempcord/framework/pull/9), which is open right now — was taken on the word of whoever opened it. That is the more urgent half of this PR.

## Checks

- `tests.yml` — PHPUnit on 8.5 and 8.6.
- `static-analysis.yml` — PHPStan on 8.5.

Both on pull requests and on pushes to `master`.

## Releases

Same rules as the library. semantic-release reads the subjects since the last tag, decides patch / minor / major, and writes the tag, the GitHub release and `CHANGELOG.md`. A merge carrying only `docs` or `chore` releases nothing.

| Prefix | Release |
| --- | --- |
| `fix`, `perf` | patch |
| `feat` | minor |
| `feat!` or `BREAKING CHANGE:` | major |
| `docs`, `test`, `refactor`, `build`, `ci`, `chore` | none |

**Worth knowing before 0.8.0 goes out:** below `1.0.0`, a breaking change is still only a minor bump. That is Conventional Commits' own rule, not an oversight here — `feat!` on `0.7.0` gives `0.8.0`, not `1.0.0`.

No version goes into `composer.json` — Packagist reads tags.

## Why the pull request title is checked

Merges are squashed with the **PR title** as the commit subject, so that title is what semantic-release reads. A title it cannot parse is not an error anywhere; it is a release that silently never happens. The check rejects one while the mistake is still cheap.

Needs the repository set to squash-only with the squash subject taken from the PR title rather than `COMMIT_OR_PR_TITLE`, otherwise a single-commit PR lands its own subject and bypasses the check. Settings change, not a code one.

## Also here

- `dependabot.yml` — composer bumps as `fix`, action bumps as `ci`, weekly. This is what will raise the `tempcord/discord-php` bump when the library releases.
- `CONTRIBUTING.md`.

## Order

Merge this **before** [#9](https://github.com/Tempcord/framework/pull/9), so that one finally gets checks run against it.