### PR TITLE
feat(commands): hand a context menu what it was used on

### DIFF
--- a/docs/guides/02-commands.md
+++ b/docs/guides/02-commands.md
@@ -161,3 +161,44 @@ final class GuildAlphaCommand
 ```
 
 <small>From [`tests/Fixtures/GuildAlphaCommand.php`](../../tests/Fixtures/GuildAlphaCommand.php) — compiled and exercised by the test suite.</small>
+
+## Context menus
+
+A command can also be something people reach for by right-clicking a user or a
+message, rather than by typing. Say so with `type`, and give it a name — Discord
+shows that name verbatim, so it is not derived from the class:
+
+```php
+use Tempcord\Discord\Enums\ApplicationCommandTypes;
+use Tempcord\Discord\Interaction\CommandInteraction;
+use Tempcord\Discord\Parts\User;
+use Tempcord\Attributes\Command;
+
+/**
+ * A context menu on a user. Discord shows the name verbatim, so it is given
+ * rather than derived from the class.
+ */
+#[Command(name: 'Профіль', type: ApplicationCommandTypes::USER)]
+final class ProfileContextMenu
+{
+    /** @var list<string> */
+    public static array $targets = [];
+
+    public function __invoke(CommandInteraction $interaction, User $target): void
+    {
+        self::$targets[] = $target->id;
+    }
+}
+```
+
+<small>From [`tests/Fixtures/ProfileContextMenu.php`](../../tests/Fixtures/ProfileContextMenu.php) — compiled and exercised by the test suite.</small>
+
+There are no options on a context menu. What it was used on arrives beside them,
+and the parameter's own type says which shape of it you want: `User` or
+`GuildMember` for a user menu, `Message` for a message menu.
+
+A member target is given back its user, which Discord leaves empty because it
+sends the two halves separately.
+
+A context menu needs no description, and giving one is refused — Discord has
+nowhere to show it.

--- a/src/Compiler/CommandCompiler.php
+++ b/src/Compiler/CommandCompiler.php
@@ -108,6 +108,17 @@ final readonly class CommandCompiler
             throw new LogicException("Description for command [{$name}] is required when type=CHAT_INPUT");
         }
 
+        /*
+         * Discord has nowhere to show a description on a context menu, so one
+         * written here would be dropped on the way out. Saying so is cheaper
+         * than wondering later why it never appears.
+         */
+        if ($command->type !== ApplicationCommandTypes::CHAT_INPUT && $command->description !== null) {
+            throw new LogicException(
+                "Command [{$name}] is a context menu, which Discord shows without a description",
+            );
+        }
+
         return new CommandDefinition(
             name: $name,
             description: $command->description,

--- a/src/Runtime/ArgumentResolver.php
+++ b/src/Runtime/ArgumentResolver.php
@@ -23,6 +23,7 @@ final readonly class ArgumentResolver
 
     public function __construct(
         private OptionValueResolver $values,
+        private TargetResolver $targets = new TargetResolver(),
     ) {}
 
     /**
@@ -55,6 +56,18 @@ final readonly class ArgumentResolver
 
             if (array_key_exists($name, $supplied)) {
                 $arguments[] = $supplied[$name];
+                continue;
+            }
+
+            /*
+             * A context menu has no options at all: what it was used on
+             * arrives beside them, and the parameter's type says which shape
+             * of it the handler wants.
+             */
+            $target = $this->targets->resolve($interaction, $parameter);
+
+            if ($target !== null) {
+                $arguments[] = $target;
                 continue;
             }
 

--- a/src/Runtime/TargetResolver.php
+++ b/src/Runtime/TargetResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tempcord\Runtime;
+
+use Tempcord\Discord\Interaction\CommandInteraction;
+use Tempcord\Discord\Parts\GuildMember;
+use Tempcord\Discord\Parts\Message;
+use Tempcord\Discord\Parts\User;
+use Tempest\Reflection\ParameterReflector;
+
+/**
+ * What a context menu was used on.
+ *
+ * A context menu carries no options — Discord names the target in
+ * `data.target_id` and puts the object itself in `data.resolved`. So there is
+ * nothing for the option resolver to find, and without this a handler could
+ * only take the raw interaction and dig the target out by hand.
+ *
+ * The parameter's own type says which shape is wanted, the same way it does
+ * for a component interaction.
+ */
+final readonly class TargetResolver
+{
+    /**
+     * The target as this parameter asks for it.
+     *
+     * Returns null when the interaction is not a context menu, or the
+     * parameter is typed as something a target is never delivered as — in
+     * which case the caller falls back to the parameter's own default.
+     */
+    public function resolve(CommandInteraction $interaction, ParameterReflector $parameter): ?object
+    {
+        $data = $interaction->interaction->data ?? null;
+        $targetId = $data->target_id ?? null;
+
+        if ($targetId === null || !$parameter->getReflection()->hasType()) {
+            return null;
+        }
+
+        return match ($parameter->getType()->getName()) {
+            User::class => $data->resolved->users[$targetId] ?? null,
+            Message::class => $data->resolved->messages[$targetId] ?? null,
+            GuildMember::class => $this->member($interaction, $targetId),
+            default => null,
+        };
+    }
+
+    /**
+     * The member a user context menu was used on.
+     *
+     * Discord sends the member and the user separately and leaves the member's
+     * own `user` empty, since it would only repeat what is already there. A
+     * handler asking for a member still expects to reach their id, so the two
+     * halves are put back together.
+     */
+    private function member(CommandInteraction $interaction, string $targetId): ?GuildMember
+    {
+        $data = $interaction->interaction->data;
+        $member = $data->resolved->members[$targetId] ?? null;
+
+        if ($member === null) {
+            return null;
+        }
+
+        $member->user ??= $data->resolved->users[$targetId] ?? null;
+
+        return $member;
+    }
+}

--- a/tests/Fixtures/DescribedContextMenu.php
+++ b/tests/Fixtures/DescribedContextMenu.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Discord\Enums\ApplicationCommandTypes;
+use Tempcord\Attributes\Command;
+
+#[Command(name: 'Опис', description: 'Discord has nowhere to show this', type: ApplicationCommandTypes::USER)]
+final class DescribedContextMenu
+{
+    public function __invoke(): void {}
+}

--- a/tests/Fixtures/MemberContextMenu.php
+++ b/tests/Fixtures/MemberContextMenu.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Discord\Enums\ApplicationCommandTypes;
+use Tempcord\Discord\Interaction\CommandInteraction;
+use Tempcord\Discord\Parts\GuildMember;
+use Tempcord\Attributes\Command;
+
+#[Command(name: 'Ролі', type: ApplicationCommandTypes::USER)]
+final class MemberContextMenu
+{
+    /** @var list<GuildMember> */
+    public static array $targets = [];
+
+    public function __invoke(CommandInteraction $interaction, GuildMember $target): void
+    {
+        self::$targets[] = $target;
+    }
+}

--- a/tests/Fixtures/ProfileContextMenu.php
+++ b/tests/Fixtures/ProfileContextMenu.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Discord\Enums\ApplicationCommandTypes;
+use Tempcord\Discord\Interaction\CommandInteraction;
+use Tempcord\Discord\Parts\User;
+use Tempcord\Attributes\Command;
+
+/**
+ * A context menu on a user. Discord shows the name verbatim, so it is given
+ * rather than derived from the class.
+ */
+#[Command(name: 'Профіль', type: ApplicationCommandTypes::USER)]
+final class ProfileContextMenu
+{
+    /** @var list<string> */
+    public static array $targets = [];
+
+    public function __invoke(CommandInteraction $interaction, User $target): void
+    {
+        self::$targets[] = $target->id;
+    }
+}

--- a/tests/Fixtures/ReportContextMenu.php
+++ b/tests/Fixtures/ReportContextMenu.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Discord\Enums\ApplicationCommandTypes;
+use Tempcord\Discord\Interaction\CommandInteraction;
+use Tempcord\Discord\Parts\Message;
+use Tempcord\Attributes\Command;
+
+#[Command(name: 'Поскаржитись', type: ApplicationCommandTypes::MESSAGE)]
+final class ReportContextMenu
+{
+    /** @var list<string> */
+    public static array $targets = [];
+
+    public function __invoke(CommandInteraction $interaction, Message $target): void
+    {
+        self::$targets[] = $target->id;
+    }
+}

--- a/tests/Unit/Runtime/TargetResolverTest.php
+++ b/tests/Unit/Runtime/TargetResolverTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Tempcord\Tests\Unit\Runtime;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Tempcord\Discord\Enums\ApplicationCommandTypes;
+use Tempcord\Discord\Gateway\Events\InteractionCreate;
+use Tempcord\Discord\Interaction\CommandInteraction;
+use Tempcord\Discord\Parts\GuildMember;
+use Tempcord\Discord\Parts\InteractionData;
+use Tempcord\Discord\Parts\InteractionDataResolved;
+use Tempcord\Discord\Parts\Message;
+use Tempcord\Discord\Parts\User;
+use Tempcord\Runtime\ArgumentResolver;
+use Tempcord\Runtime\OptionValueResolver;
+use Tempcord\Runtime\TargetResolver;
+use Tempcord\Tests\Doubles\FakeDiscord;
+use Tempcord\Tests\Doubles\RecordingHttp;
+use LogicException;
+use Tempcord\Tests\Fixtures\BareCommand;
+use Tempcord\Tests\Fixtures\DescribedContextMenu;
+use Tempcord\Tests\Fixtures\MemberContextMenu;
+use Tempcord\Tests\Fixtures\ProfileContextMenu;
+use Tempcord\Tests\Fixtures\ReportContextMenu;
+use Tempcord\Tests\Unit\TestCase;
+
+/**
+ * What a context menu was used on.
+ *
+ * A context menu carries no options, so there is nothing for the option
+ * resolver to find — without this a handler could only take the raw
+ * interaction and dig the target out of the payload by hand.
+ */
+#[CoversClass(TargetResolver::class)]
+#[CoversClass(ArgumentResolver::class)]
+final class TargetResolverTest extends TestCase
+{
+    private function user(string $id): User
+    {
+        $user = new User();
+        $user->id = $id;
+        $user->username = 'user-' . $id;
+
+        return $user;
+    }
+
+    /**
+     * A context menu interaction as Discord sends one: the target named by id,
+     * and the object itself alongside.
+     */
+    private function interaction(string $name, string $targetId, ?callable $fill = null): CommandInteraction
+    {
+        $resolved = new InteractionDataResolved();
+
+        if ($fill !== null) {
+            $fill($resolved);
+        }
+
+        $data = new InteractionData();
+        $data->name = $name;
+        $data->target_id = $targetId;
+        $data->resolved = $resolved;
+        $data->options = [];
+
+        $interaction = new InteractionCreate();
+        $interaction->id = '1';
+        $interaction->token = 'token';
+        $interaction->data = $data;
+
+        return new CommandInteraction($interaction, new FakeDiscord(new RecordingHttp()));
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function arguments(string $class, string $path, CommandInteraction $interaction): array
+    {
+        $handler = $this->definition($class)->handlers[$path];
+
+        return new ArgumentResolver(
+            new OptionValueResolver(new FakeDiscord(new RecordingHttp())),
+        )->resolve($handler, $interaction);
+    }
+
+    public function test_a_user_menu_hands_over_the_user_it_was_used_on(): void
+    {
+        $interaction = $this->interaction('Профіль', '99', static function (InteractionDataResolved $r): void {
+            $r->users = ['99' => new User()];
+            $r->users['99']->id = '99';
+        });
+
+        $arguments = $this->arguments(ProfileContextMenu::class, 'Профіль', $interaction);
+
+        $this->assertSame($interaction, $arguments[0]);
+        $this->assertInstanceOf(User::class, $arguments[1]);
+        $this->assertSame('99', $arguments[1]->id);
+    }
+
+    public function test_a_message_menu_hands_over_the_message(): void
+    {
+        $message = new Message();
+        $message->id = 'm1';
+
+        $interaction = $this->interaction('Поскаржитись', 'm1', static function (InteractionDataResolved $r) use ($message): void {
+            $r->messages = ['m1' => $message];
+        });
+
+        $arguments = $this->arguments(ReportContextMenu::class, 'Поскаржитись', $interaction);
+
+        $this->assertSame($message, $arguments[1]);
+    }
+
+    /**
+     * Discord sends the member and the user separately, leaving the member's
+     * own user empty because it would only repeat what is already there. A
+     * handler asking for a member still expects to reach their id.
+     */
+    public function test_a_member_target_is_given_back_its_user(): void
+    {
+        $member = new GuildMember();
+        $member->user = null;
+        $member->nick = 'Vlad';
+
+        $interaction = $this->interaction('Ролі', '99', function (InteractionDataResolved $r) use ($member): void {
+            $r->members = ['99' => $member];
+            $r->users = ['99' => $this->user('99')];
+        });
+
+        $arguments = $this->arguments(MemberContextMenu::class, 'Ролі', $interaction);
+
+        $this->assertInstanceOf(GuildMember::class, $arguments[1]);
+        $this->assertSame('Vlad', $arguments[1]->nick);
+        $this->assertSame('99', $arguments[1]->user?->id);
+    }
+
+    /**
+     * A member Discord did send a user for keeps it rather than being
+     * overwritten.
+     */
+    public function test_a_member_that_already_carries_a_user_is_left_alone(): void
+    {
+        $member = new GuildMember();
+        $member->user = $this->user('original');
+
+        $interaction = $this->interaction('Ролі', '99', function (InteractionDataResolved $r) use ($member): void {
+            $r->members = ['99' => $member];
+            $r->users = ['99' => $this->user('99')];
+        });
+
+        $arguments = $this->arguments(MemberContextMenu::class, 'Ролі', $interaction);
+
+        $this->assertSame('original', $arguments[1]->user?->id);
+    }
+
+    /**
+     * A target Discord named but did not resolve leaves the parameter unfilled,
+     * which is a missing required argument rather than a silent null.
+     */
+    public function test_an_unresolved_target_is_reported(): void
+    {
+        $this->expectExceptionMessage('Missing required parameter: target');
+
+        $this->arguments(
+            ProfileContextMenu::class,
+            'Профіль',
+            $this->interaction('Профіль', '99'),
+        );
+    }
+
+    /**
+     * An ordinary slash command has no target, and nothing about how its
+     * arguments are filled changes.
+     */
+    public function test_a_slash_command_is_untouched(): void
+    {
+        $data = new InteractionData();
+        $data->name = 'bare';
+        $data->options = [];
+
+        $interaction = new InteractionCreate();
+        $interaction->id = '1';
+        $interaction->token = 'token';
+        $interaction->data = $data;
+
+        $arguments = $this->arguments(
+            BareCommand::class,
+            'bare',
+            new CommandInteraction($interaction, new FakeDiscord(new RecordingHttp())),
+        );
+
+        $this->assertSame([], $arguments);
+    }
+
+    public function test_a_context_menu_carries_no_description_and_keeps_its_type(): void
+    {
+        $definition = $this->definition(ProfileContextMenu::class);
+
+        $this->assertSame(ApplicationCommandTypes::USER, $definition->type);
+        $this->assertNull($definition->description);
+        $this->assertSame([], $definition->options);
+    }
+
+    /**
+     * Discord shows a context menu without a description, so one written here
+     * would be dropped on the way out — which is worth saying rather than
+     * leaving someone to wonder why it never appears.
+     */
+    public function test_a_context_menu_with_a_description_is_refused(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('shows without a description');
+
+        $this->definition(DescribedContextMenu::class);
+    }
+}

--- a/tools/guides/02-commands.md
+++ b/tools/guides/02-commands.md
@@ -69,3 +69,21 @@ immediately, which makes them useful while developing; global commands can take 
 hour to propagate.
 
 <!-- include: tests/Fixtures/GuildAlphaCommand.php -->
+
+## Context menus
+
+A command can also be something people reach for by right-clicking a user or a
+message, rather than by typing. Say so with `type`, and give it a name — Discord
+shows that name verbatim, so it is not derived from the class:
+
+<!-- include: tests/Fixtures/ProfileContextMenu.php -->
+
+There are no options on a context menu. What it was used on arrives beside them,
+and the parameter's own type says which shape of it you want: `User` or
+`GuildMember` for a user menu, `Message` for a message menu.
+
+A member target is given back its user, which Discord leaves empty because it
+sends the two halves separately.
+
+A context menu needs no description, and giving one is refused — Discord has
+nowhere to show it.


### PR DESCRIPTION
Context menus were supported on paper — `#[Command(type: ApplicationCommandTypes::USER)]` compiles and registers — but **there was no way to reach the thing the menu was used on**, and no test covering any of it.

## The gap

A context menu carries no options. Discord names the target in `data.target_id` and puts the object beside it in `data.resolved`. `ArgumentResolver` only ever looked at options, so nothing could fill a parameter and a handler was left with the raw interaction:

```php
$targetId = $interaction->interaction->data->target_id;
$user = $interaction->interaction->data->resolved->users[$targetId] ?? null;
```

Seven of the commands still to be ported from the old bot are context menus, so that would have been written seven times.

## Now

```php
#[Command(name: 'Профіль', type: ApplicationCommandTypes::USER)]
final class ProfileContextMenu
{
    public function __invoke(CommandInteraction $interaction, User $target): void { … }
}
```

The parameter's own type says which shape is wanted — `User` or `GuildMember` for a user menu, `Message` for a message menu — the same way it already works for a component interaction.

A `GuildMember` target is given back its user. Discord sends the member and the user separately and leaves the member's own `user` empty, since it would only repeat what is already there; a handler asking for a member still expects to reach an id.

A target Discord named but did not resolve leaves the parameter unfilled, which surfaces as the ordinary missing-argument error rather than a silent null.

## Also

A description on a context menu is now **refused** rather than dropped on the way out. Discord has nowhere to show one, and `CommandBuilderFactory` was quietly skipping it — the kind of thing that costs an afternoon. The guide previously claimed this was already the behaviour; now it is.

## Checks

`composer test` — 256 tests, 503 assertions. `composer analyse` — clean. Docs regenerated.