### PR TITLE
feat(scheduling): declare recurring work with #[Scheduled]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,12 +14,13 @@ Build Discord bots with PHP, on top of [Tempest](https://tempestphp.com).
 - [Plugins](guides/06-plugins.md)
 - [Components](guides/07-components.md)
 - [Cache](guides/08-cache.md)
+- [Scheduled tasks](guides/09-scheduled-tasks.md)
 
 ## Reference
 
 Generated from the source, so it describes what the framework actually does.
 
-**Attributes** — [Command](reference/attributes/command.md), [SubcommandGroup](reference/attributes/subcommand-group.md), [Subcommand](reference/attributes/subcommand.md), [Option](reference/attributes/option.md), [Event](reference/attributes/event.md), [Autocomplete](reference/attributes/autocomplete.md), [Button](reference/attributes/button.md), [SelectMenu](reference/attributes/select-menu.md), [ModalSubmit](reference/attributes/modal-submit.md)
+**Attributes** — [Command](reference/attributes/command.md), [SubcommandGroup](reference/attributes/subcommand-group.md), [Subcommand](reference/attributes/subcommand.md), [Option](reference/attributes/option.md), [Event](reference/attributes/event.md), [Autocomplete](reference/attributes/autocomplete.md), [Button](reference/attributes/button.md), [SelectMenu](reference/attributes/select-menu.md), [ModalSubmit](reference/attributes/modal-submit.md), [Scheduled](reference/attributes/scheduled.md)
 
 **Autocomplete** — [Autocomplete](reference/autocomplete/autocomplete.md), [ArrayAutocomplete](reference/autocomplete/array-autocomplete.md)
 

--- a/docs/guides/09-scheduled-tasks.md
+++ b/docs/guides/09-scheduled-tasks.md
@@ -1,0 +1,68 @@
+# Scheduled tasks
+
+Some of what a bot does is not a reply to anything: sweeping rows that have run their
+course, lifting blocks that have expired, polling a service with no gateway event of its
+own. `#[Scheduled]` declares an invokable class as work the bot does on a timer.
+
+```php
+use Tempcord\Attributes\Scheduled;
+
+#[Scheduled(everySeconds: 10)]
+final readonly class SweepTemporaryMessages
+{
+    public function __construct(private TempMessages $messages) {}
+
+    public function __invoke(): void
+    {
+        $this->messages->sweep();
+    }
+}
+```
+
+That is the whole registration. The class is discovered like a command or a listener, is
+built by the container so it may take whatever dependencies it needs, and is put on the
+event loop before the gateway opens.
+
+## What the framework guarantees
+
+A timer is less forgiving than an event listener: it fires again whether or not the last
+turn finished or threw, forever. Three things are handled so you do not have to write them
+into every task.
+
+- **A task that throws is logged and keeps its place.** Without that the exception travels
+  into the event loop, and the usual result is that the timer is cancelled and nothing is
+  ever swept again — silently, because the bot carries on answering commands.
+- **A task is never started alongside itself.** If a turn is still running when the next
+  one is due, that turn is skipped and the skip is logged. Otherwise a task slower than its
+  own interval makes every following turn slower until nothing else gets a look in.
+- **Each turn runs in a fiber**, so a task may `await` the REST API exactly as a command
+  handler does.
+
+## The first turn
+
+The first turn comes after the interval, not at boot. A scheduled task is a repeating
+chore; something that must happen once at startup — a reconciliation against what changed
+while the bot was down — belongs in a plugin's `boot()`, where its ordering against
+everything else is visible.
+
+```php
+final readonly class VoicePlugin implements Plugin
+{
+    public function __construct(private VoiceReconciler $reconciler) {}
+
+    public function boot(Tempcord $tempcord): void
+    {
+        $this->reconciler->catchUp();
+    }
+}
+```
+
+## Choosing an interval
+
+`everySeconds` is a float, so sub-second intervals are allowed, and zero is refused at
+discovery — it asks the loop to run the task as fast as it can, which starves the gateway
+heartbeat and drops the connection.
+
+Prefer one cheap sweep that runs often over a clever one that runs rarely: a query over an
+indexed `expires_at` costs almost nothing, and a task that runs every ten seconds needs no
+reasoning about when it last ran or what it missed across a restart.

--- a/docs/index.json
+++ b/docs/index.json
@@ -31,6 +31,10 @@
         {
             "title": "Cache",
             "slug": "guides/08-cache"
+        },
+        {
+            "title": "Scheduled tasks",
+            "slug": "guides/09-scheduled-tasks"
         }
     ],
     "reference": {
@@ -320,6 +324,25 @@
                         "default": "null",
                         "required": false,
                         "summary": "the modal's custom id, which may carry {placeholders}. Defaults to the class name with a ModalSubmit or Modal prefix or suffix stripped and the rest snake_cased."
+                    }
+                ],
+                "cases": [],
+                "methods": []
+            },
+            {
+                "name": "Scheduled",
+                "fqcn": "Tempcord\\Attributes\\Scheduled",
+                "kind": "attribute",
+                "target": "class",
+                "summary": "Declares an invokable class as work the bot does on a timer.",
+                "slug": "reference/attributes/scheduled",
+                "parameters": [
+                    {
+                        "name": "everySeconds",
+                        "type": "float",
+                        "default": null,
+                        "required": true,
+                        "summary": ""
                     }
                 ],
                 "cases": [],

--- a/docs/reference/attributes/scheduled.md
+++ b/docs/reference/attributes/scheduled.md
@@ -1,0 +1,18 @@
+<!-- Generated from the source by `composer docs`. Do not edit by hand. -->
+
+# Scheduled
+
+Declares an invokable class as work the bot does on a timer.
+
+```php
+use Tempcord\Attributes\Scheduled;
+```
+
+**Applies to:** class
+
+## Parameters
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `everySeconds` | `float` | *required* |  |
+

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -13,6 +13,7 @@
 - [Button](attributes/button.md) — Declares a class or method as the handler for a button press.
 - [SelectMenu](attributes/select-menu.md) — Declares a class or method as the handler for a select menu choice.
 - [ModalSubmit](attributes/modal-submit.md) — Declares a class or method as the handler for a submitted modal.
+- [Scheduled](attributes/scheduled.md) — Declares an invokable class as work the bot does on a timer.
 
 ## Autocomplete
 

--- a/src/Attributes/Scheduled.php
+++ b/src/Attributes/Scheduled.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tempcord\Attributes;
+
+use Attribute;
+
+/**
+ * Declares an invokable class as work the bot does on a timer.
+ *
+ * Sweeping rows that have run their course, expiring caches, polling something
+ * that has no gateway event — anything that has to happen whether or not
+ * anyone is interacting with the bot.
+ *
+ * The first turn comes after the interval, not at boot: a task is a repeating
+ * chore, and something that must happen once at startup belongs in a plugin's
+ * boot method where its ordering against everything else is visible.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Scheduled
+{
+    public function __construct(
+        public float $everySeconds,
+    ) {}
+}

--- a/src/Compiler/ScheduledTaskCompiler.php
+++ b/src/Compiler/ScheduledTaskCompiler.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tempcord\Compiler;
+
+use RuntimeException;
+use Tempcord\Attributes\Scheduled;
+use Tempcord\Definitions\ScheduledTaskDefinition;
+use Tempest\Reflection\ClassReflector;
+
+final readonly class ScheduledTaskCompiler
+{
+    public function compile(ClassReflector $class, Scheduled $scheduled): ScheduledTaskDefinition
+    {
+        if (!$class->getReflection()->hasMethod('__invoke')) {
+            throw new RuntimeException(
+                'Class [' . $class->getName() . '] should declare an __invoke method',
+            );
+        }
+
+        /*
+         * An interval of zero asks the loop to run the task as fast as it can,
+         * which starves everything else including the gateway heartbeat. That
+         * is never what someone meant to write.
+         */
+        if ($scheduled->everySeconds <= 0) {
+            throw new RuntimeException(
+                'Scheduled task [' . $class->getName() . '] must run at an interval greater than zero.',
+            );
+        }
+
+        return new ScheduledTaskDefinition(
+            task: $class->getName(),
+            everySeconds: $scheduled->everySeconds,
+            method: $class->getMethod('__invoke'),
+        );
+    }
+}

--- a/src/Definitions/ScheduledTaskDefinition.php
+++ b/src/Definitions/ScheduledTaskDefinition.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tempcord\Definitions;
+
+use Tempest\Reflection\MethodReflector;
+
+/**
+ * A piece of recurring work paired with how often it runs.
+ */
+final readonly class ScheduledTaskDefinition
+{
+    public function __construct(
+        public string $task,
+        public float $everySeconds,
+        public MethodReflector $method,
+    ) {}
+}

--- a/src/Discoveries/ScheduledTasksDiscovery.php
+++ b/src/Discoveries/ScheduledTasksDiscovery.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tempcord\Discoveries;
+
+use Tempcord\Attributes\Scheduled;
+use Tempcord\Compiler\ScheduledTaskCompiler;
+use Tempcord\Registries\ScheduledTasksRegistry;
+use Tempest\Discovery\Discovery;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Discovery\IsDiscovery;
+use Tempest\Reflection\ClassReflector;
+
+final class ScheduledTasksDiscovery implements Discovery
+{
+    use IsDiscovery;
+
+    public function __construct(
+        private readonly ScheduledTasksRegistry $registry,
+        private readonly ScheduledTaskCompiler $compiler = new ScheduledTaskCompiler(),
+    ) {}
+
+    public function discover(DiscoveryLocation $location, ClassReflector $class): void
+    {
+        foreach ($class->getAttributes(Scheduled::class) as $attribute) {
+            $this->discoveryItems->add($location, $this->compiler->compile($class, $attribute));
+        }
+    }
+
+    public function apply(): void
+    {
+        foreach ($this->discoveryItems as $task) {
+            $this->registry->add($task);
+        }
+    }
+}

--- a/src/Registries/ScheduledTasksRegistry.php
+++ b/src/Registries/ScheduledTasksRegistry.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tempcord\Registries;
+
+use React\EventLoop\LoopInterface;
+use Tempcord\Definitions\ScheduledTaskDefinition;
+use Tempcord\Runtime\Outcome;
+use Tempcord\Runtime\TaskRunner;
+use Tempest\Container\Container;
+use Tempest\Container\Singleton;
+
+/**
+ * Holds every discovered scheduled task and puts it on the event loop.
+ */
+#[Singleton]
+final class ScheduledTasksRegistry
+{
+    /** @var list<ScheduledTaskDefinition> */
+    private array $tasks = [];
+
+    public function __construct(
+        private readonly Container $container,
+    ) {}
+
+    public function add(ScheduledTaskDefinition $task): void
+    {
+        $this->tasks[] = $task;
+    }
+
+    /**
+     * @return list<ScheduledTaskDefinition>
+     */
+    public function all(): array
+    {
+        return $this->tasks;
+    }
+
+    /**
+     * Timers do not fire until the loop runs, which is after the gateway opens,
+     * so this only has to happen before then.
+     *
+     * @return list<Outcome>
+     */
+    public function start(LoopInterface $loop): array
+    {
+        if ($this->tasks === []) {
+            return [];
+        }
+
+        /*
+         * Resolved here rather than in the constructor: discovery builds this
+         * registry while the container is still being assembled, before the
+         * initializers that provide the logger have themselves been found.
+         */
+        $runner = $this->container->get(TaskRunner::class);
+        $outcomes = [];
+
+        foreach ($this->tasks as $task) {
+            $loop->addPeriodicTimer(
+                $task->everySeconds,
+                static fn() => $runner->run($task),
+            );
+
+            $outcomes[] = Outcome::success(
+                'Scheduled ' . $task->task . ' every ' . $task->everySeconds . 's.',
+            );
+        }
+
+        return $outcomes;
+    }
+}

--- a/src/Runtime/TaskRunner.php
+++ b/src/Runtime/TaskRunner.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tempcord\Runtime;
+
+use Tempcord\Definitions\ScheduledTaskDefinition;
+use Tempest\Container\Container;
+use Tempest\Log\Logger;
+use Throwable;
+
+use function React\Async\async;
+
+/**
+ * Takes one turn of a scheduled task.
+ *
+ * A timer is unforgiving in a way an event listener is not: it fires again
+ * whether or not the last turn finished or threw, forever. Both are contained
+ * here so that neither can quietly stop the bot doing its other work.
+ */
+final class TaskRunner
+{
+    /** @var array<string, true> tasks whose previous turn has not finished */
+    private array $running = [];
+
+    public function __construct(
+        private readonly Container $container,
+        private readonly Logger $logger,
+    ) {}
+
+    public function run(ScheduledTaskDefinition $task): void
+    {
+        /*
+         * A task that takes longer than its own interval would otherwise be
+         * started again alongside itself, and each turn would make the next
+         * one slower until nothing else got a look in.
+         */
+        if (isset($this->running[$task->task])) {
+            $this->logger->warning(
+                'Scheduled task ' . $task->task . ' is still busy from its last turn; skipping this one.',
+            );
+
+            return;
+        }
+
+        $this->running[$task->task] = true;
+
+        /*
+         * In a fiber, so a task may await the REST API, and inside a catch, so
+         * one that throws is logged rather than travelling up into the event
+         * loop and taking the process with it.
+         */
+        async(function () use ($task): void {
+            try {
+                $task->method->invokeArgs($this->container->get($task->task), []);
+            } catch (Throwable $throwable) {
+                $this->logger->error(
+                    'Scheduled task ' . $task->task . ' failed: ' . $throwable->getMessage(),
+                    ['exception' => $throwable],
+                );
+            } finally {
+                unset($this->running[$task->task]);
+            }
+        })();
+    }
+}

--- a/src/Tempcord.php
+++ b/src/Tempcord.php
@@ -10,11 +10,13 @@ use Tempcord\Registries\CommandsRegistry;
 use Tempcord\Registries\ComponentsRegistry;
 use Tempcord\Registries\EventsRegistry;
 use Tempcord\Registries\PluginsRegistry;
+use Tempcord\Registries\ScheduledTasksRegistry;
 use Tempcord\Runtime\CommandBinder;
 use Tempcord\Runtime\CommandRegistrar;
 use Tempcord\Runtime\ComponentBinder;
 use Tempcord\Runtime\Outcome;
 use Tempcord\Runtime\PluginBooter;
+use React\EventLoop\Loop;
 
 /**
  * The bot itself: the Discord connection, the registries that were filled
@@ -30,6 +32,7 @@ final class Tempcord
         private readonly ComponentsRegistry $componentsRegistry,
         private readonly EventsRegistry $eventsRegistry,
         private readonly PluginsRegistry $pluginsRegistry,
+        private readonly ScheduledTasksRegistry $scheduledTasksRegistry,
         private readonly CommandRegistrar $registrar,
         private readonly CommandBinder $binder,
         private readonly ComponentBinder $componentBinder,
@@ -56,8 +59,11 @@ final class Tempcord
      *
      * The cache subscribes first, so a listener reading it sees the state the
      * event it is handling has already produced. Plugins boot last, so whatever
-     * they do runs against a bot whose commands and events are already bound,
-     * and still before the gateway opens.
+     * they do runs against a bot whose commands, events and timers are already
+     * in place, and still before the gateway opens.
+     *
+     * Scheduled tasks are only put on the loop here; none of them takes a turn
+     * until the loop itself runs, which is after the gateway opens.
      *
      * @return list<Outcome>
      */
@@ -68,6 +74,7 @@ final class Tempcord
             ...$this->binder->bindAll($this->commandsRegistry->all()),
             ...$this->componentBinder->bindAll($this->componentsRegistry->all()),
             ...$this->eventsRegistry->listen($this->discord),
+            ...$this->scheduledTasksRegistry->start(Loop::get()),
             ...$this->pluginBooter->bootAll($this->pluginsRegistry->all(), $this),
         ];
     }

--- a/src/TempcordInitializer.php
+++ b/src/TempcordInitializer.php
@@ -8,6 +8,7 @@ use Tempcord\Registries\CommandsRegistry;
 use Tempcord\Registries\ComponentsRegistry;
 use Tempcord\Registries\EventsRegistry;
 use Tempcord\Registries\PluginsRegistry;
+use Tempcord\Registries\ScheduledTasksRegistry;
 use Tempcord\Runtime\CommandBinder;
 use Tempcord\Runtime\CommandRegistrar;
 use Tempcord\Runtime\ComponentBinder;
@@ -27,6 +28,7 @@ final readonly class TempcordInitializer implements Initializer
             componentsRegistry: $container->get(ComponentsRegistry::class),
             eventsRegistry: $container->get(EventsRegistry::class),
             pluginsRegistry: $container->get(PluginsRegistry::class),
+            scheduledTasksRegistry: $container->get(ScheduledTasksRegistry::class),
             registrar: $container->get(CommandRegistrar::class),
             binder: $container->get(CommandBinder::class),
             componentBinder: $container->get(ComponentBinder::class),

--- a/tests/Fixtures/FailingTask.php
+++ b/tests/Fixtures/FailingTask.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use RuntimeException;
+use Tempcord\Attributes\Scheduled;
+
+#[Scheduled(everySeconds: 0.01)]
+final class FailingTask
+{
+    public function __invoke(): void
+    {
+        throw new RuntimeException('the database went away');
+    }
+}

--- a/tests/Fixtures/HandlerlessTask.php
+++ b/tests/Fixtures/HandlerlessTask.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Scheduled;
+
+#[Scheduled(everySeconds: 10)]
+final class HandlerlessTask
+{
+}

--- a/tests/Fixtures/SlowTask.php
+++ b/tests/Fixtures/SlowTask.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use React\Promise\Deferred;
+use Tempcord\Attributes\Scheduled;
+
+use function React\Async\await;
+
+/**
+ * A task that outlasts its own interval, held open by the test until it is
+ * ready to let it finish.
+ */
+#[Scheduled(everySeconds: 0.01)]
+final class SlowTask
+{
+    public static int $started = 0;
+
+    public static ?Deferred $holding = null;
+
+    public function __invoke(): void
+    {
+        self::$started++;
+
+        await(self::$holding->promise());
+    }
+}

--- a/tests/Fixtures/SweepTask.php
+++ b/tests/Fixtures/SweepTask.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Scheduled;
+
+/**
+ * The ordinary case: a chore that runs often and finishes quickly.
+ */
+#[Scheduled(everySeconds: 0.01)]
+final class SweepTask
+{
+    public static int $turns = 0;
+
+    public function __invoke(): void
+    {
+        self::$turns++;
+    }
+}

--- a/tests/Fixtures/UnscheduledTask.php
+++ b/tests/Fixtures/UnscheduledTask.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Scheduled;
+
+/**
+ * An interval of zero asks the loop to run this as fast as it can, starving
+ * everything else including the gateway heartbeat.
+ */
+#[Scheduled(everySeconds: 0)]
+final class UnscheduledTask
+{
+    public function __invoke(): void {}
+}

--- a/tests/Unit/Scheduling/ScheduledTasksTest.php
+++ b/tests/Unit/Scheduling/ScheduledTasksTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tempcord\Tests\Unit\Scheduling;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\StreamSelectLoop;
+use React\Promise\Deferred;
+use RuntimeException;
+use Tempcord\Attributes\Scheduled;
+use Tempcord\Compiler\ScheduledTaskCompiler;
+use Tempcord\Definitions\ScheduledTaskDefinition;
+use Tempcord\Registries\ScheduledTasksRegistry;
+use Tempcord\Runtime\TaskRunner;
+use Tempcord\Tests\Doubles\RecordingLogger;
+use Tempcord\Tests\Fixtures\FailingTask;
+use Tempcord\Tests\Fixtures\HandlerlessTask;
+use Tempcord\Tests\Fixtures\SlowTask;
+use Tempcord\Tests\Fixtures\SweepTask;
+use Tempcord\Tests\Fixtures\UnscheduledTask;
+use Tempcord\Tests\Unit\TestCase;
+use Tempest\Container\GenericContainer;
+use Tempest\Log\Logger;
+use Tempest\Reflection\ClassReflector;
+
+/**
+ * Work the bot does on a timer, whether or not anyone is interacting with it.
+ */
+#[CoversClass(ScheduledTaskCompiler::class)]
+#[CoversClass(ScheduledTasksRegistry::class)]
+#[CoversClass(TaskRunner::class)]
+final class ScheduledTasksTest extends TestCase
+{
+    private RecordingLogger $logger;
+
+    private GenericContainer $container;
+
+    protected function setUp(): void
+    {
+        SweepTask::$turns = 0;
+        SlowTask::$started = 0;
+        SlowTask::$holding = new Deferred();
+
+        $this->logger = new RecordingLogger();
+        $this->container = new GenericContainer();
+        $this->container->singleton(Logger::class, $this->logger);
+    }
+
+    private function compile(string $class): ScheduledTaskDefinition
+    {
+        $reflector = new ClassReflector($class);
+
+        /** @var Scheduled $attribute */
+        $attribute = $reflector->getAttribute(Scheduled::class);
+
+        return new ScheduledTaskCompiler()->compile($reflector, $attribute);
+    }
+
+    private function registry(string ...$classes): ScheduledTasksRegistry
+    {
+        $registry = new ScheduledTasksRegistry($this->container);
+
+        foreach ($classes as $class) {
+            $registry->add($this->compile($class));
+        }
+
+        return $registry;
+    }
+
+    /**
+     * Runs the loop for long enough to see a few turns, then stops it whether
+     * or not anything happened, so a broken timer fails rather than hangs.
+     */
+    private function runFor(LoopInterface $loop, float $seconds): void
+    {
+        $loop->addTimer($seconds, static fn() => $loop->stop());
+        $loop->run();
+    }
+
+    public function test_a_task_is_compiled_with_its_interval(): void
+    {
+        $definition = $this->compile(SweepTask::class);
+
+        $this->assertSame(SweepTask::class, $definition->task);
+        $this->assertSame(0.01, $definition->everySeconds);
+    }
+
+    public function test_a_task_without_an_invoke_method_is_refused(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('should declare an __invoke method');
+
+        $this->compile(HandlerlessTask::class);
+    }
+
+    /**
+     * A zero interval asks the loop to run the task as fast as it can, which
+     * starves the gateway heartbeat and drops the connection.
+     */
+    public function test_a_task_with_no_interval_is_refused(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('greater than zero');
+
+        $this->compile(UnscheduledTask::class);
+    }
+
+    public function test_a_scheduled_task_takes_turns_on_the_loop(): void
+    {
+        $loop = new StreamSelectLoop();
+        $this->registry(SweepTask::class)->start($loop);
+
+        $this->runFor($loop, 0.05);
+
+        $this->assertGreaterThan(1, SweepTask::$turns);
+    }
+
+    /**
+     * The first turn comes after the interval: a task is a repeating chore, and
+     * something that must happen at startup belongs in a plugin's boot.
+     */
+    public function test_a_task_does_not_take_a_turn_before_its_first_interval(): void
+    {
+        $loop = new StreamSelectLoop();
+        $this->registry(SweepTask::class)->start($loop);
+
+        $this->assertSame(0, SweepTask::$turns);
+    }
+
+    public function test_starting_reports_what_was_scheduled(): void
+    {
+        $outcomes = $this->registry(SweepTask::class)->start(new StreamSelectLoop());
+
+        $this->assertCount(1, $outcomes);
+        $this->assertStringContainsString(SweepTask::class, $outcomes[0]->message);
+    }
+
+    public function test_a_bot_with_nothing_scheduled_reports_nothing(): void
+    {
+        $this->assertSame([], $this->registry()->start(new StreamSelectLoop()));
+    }
+
+    /**
+     * A timer fires again whether or not the last turn threw. Without
+     * containment the exception travels into the event loop and takes the
+     * process with it.
+     */
+    public function test_a_task_that_throws_is_reported_and_keeps_its_place(): void
+    {
+        $loop = new StreamSelectLoop();
+        $this->registry(FailingTask::class, SweepTask::class)->start($loop);
+
+        $this->runFor($loop, 0.05);
+
+        $this->assertGreaterThan(1, SweepTask::$turns);
+        $this->assertNotSame([], array_filter(
+            $this->logger->messages,
+            static fn(string $message) => str_contains($message, 'the database went away'),
+        ));
+    }
+
+    /**
+     * A task slower than its own interval must not be started alongside itself,
+     * or each turn makes the next one slower until nothing else gets a look in.
+     */
+    public function test_a_task_still_busy_from_its_last_turn_is_skipped(): void
+    {
+        $loop = new StreamSelectLoop();
+        $this->registry(SlowTask::class)->start($loop);
+
+        $this->runFor($loop, 0.05);
+
+        $this->assertSame(1, SlowTask::$started);
+        $this->assertNotSame([], array_filter(
+            $this->logger->messages,
+            static fn(string $message) => str_contains($message, 'still busy'),
+        ));
+    }
+
+    /**
+     * Once it finishes, the task goes back to taking its turns.
+     */
+    public function test_a_task_that_catches_up_is_scheduled_again(): void
+    {
+        $loop = new StreamSelectLoop();
+        $this->registry(SlowTask::class)->start($loop);
+
+        $this->runFor($loop, 0.03);
+        SlowTask::$holding->resolve(null);
+        $this->runFor($loop, 0.03);
+
+        $this->assertGreaterThan(1, SlowTask::$started);
+    }
+}

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -13,6 +13,7 @@ use Tempcord\Registries\CommandsRegistry;
 use Tempcord\Registries\ComponentsRegistry;
 use Tempcord\Registries\EventsRegistry;
 use Tempcord\Registries\PluginsRegistry;
+use Tempcord\Registries\ScheduledTasksRegistry;
 use Tempcord\Runtime\ArgumentResolver;
 use Tempcord\Runtime\AutocompleteResolver;
 use Tempcord\Runtime\AutocompleteResponder;
@@ -49,6 +50,7 @@ abstract class TestCase extends BaseTestCase
         ?ComponentsRegistry $components = null,
         ?EventsRegistry $events = null,
         ?PluginsRegistry $plugins = null,
+        ?ScheduledTasksRegistry $scheduledTasks = null,
         ?RecordingHttp $http = null,
         ?RecordingLogger $logger = null,
         ?Cache $cache = null,
@@ -67,6 +69,7 @@ abstract class TestCase extends BaseTestCase
             componentsRegistry: $components,
             eventsRegistry: $events ?? new EventsRegistry($container),
             pluginsRegistry: $plugins ?? new PluginsRegistry(),
+            scheduledTasksRegistry: $scheduledTasks ?? new ScheduledTasksRegistry($container),
             registrar: new CommandRegistrar(
                 new CommandBuilderFactory(),
                 new TempcordConfig('::token::', new Bitwise()),

--- a/tools/guides/09-scheduled-tasks.md
+++ b/tools/guides/09-scheduled-tasks.md
@@ -1,0 +1,68 @@
+# Scheduled tasks
+
+Some of what a bot does is not a reply to anything: sweeping rows that have run their
+course, lifting blocks that have expired, polling a service with no gateway event of its
+own. `#[Scheduled]` declares an invokable class as work the bot does on a timer.
+
+```php
+use Tempcord\Attributes\Scheduled;
+
+#[Scheduled(everySeconds: 10)]
+final readonly class SweepTemporaryMessages
+{
+    public function __construct(private TempMessages $messages) {}
+
+    public function __invoke(): void
+    {
+        $this->messages->sweep();
+    }
+}
+```
+
+That is the whole registration. The class is discovered like a command or a listener, is
+built by the container so it may take whatever dependencies it needs, and is put on the
+event loop before the gateway opens.
+
+## What the framework guarantees
+
+A timer is less forgiving than an event listener: it fires again whether or not the last
+turn finished or threw, forever. Three things are handled so you do not have to write them
+into every task.
+
+- **A task that throws is logged and keeps its place.** Without that the exception travels
+  into the event loop, and the usual result is that the timer is cancelled and nothing is
+  ever swept again — silently, because the bot carries on answering commands.
+- **A task is never started alongside itself.** If a turn is still running when the next
+  one is due, that turn is skipped and the skip is logged. Otherwise a task slower than its
+  own interval makes every following turn slower until nothing else gets a look in.
+- **Each turn runs in a fiber**, so a task may `await` the REST API exactly as a command
+  handler does.
+
+## The first turn
+
+The first turn comes after the interval, not at boot. A scheduled task is a repeating
+chore; something that must happen once at startup — a reconciliation against what changed
+while the bot was down — belongs in a plugin's `boot()`, where its ordering against
+everything else is visible.
+
+```php
+final readonly class VoicePlugin implements Plugin
+{
+    public function __construct(private VoiceReconciler $reconciler) {}
+
+    public function boot(Tempcord $tempcord): void
+    {
+        $this->reconciler->catchUp();
+    }
+}
+```
+
+## Choosing an interval
+
+`everySeconds` is a float, so sub-second intervals are allowed, and zero is refused at
+discovery — it asks the loop to run the task as fast as it can, which starves the gateway
+heartbeat and drops the connection.
+
+Prefer one cheap sweep that runs often over a clever one that runs rarely: a query over an
+indexed `expires_at` costs almost nothing, and a task that runs every ten seconds needs no
+reasoning about when it last ran or what it missed across a restart.

--- a/tools/src/ApiReflector.php
+++ b/tools/src/ApiReflector.php
@@ -34,6 +34,7 @@ final readonly class ApiReflector
             \Tempcord\Attributes\Button::class,
             \Tempcord\Attributes\SelectMenu::class,
             \Tempcord\Attributes\ModalSubmit::class,
+            \Tempcord\Attributes\Scheduled::class,
         ],
         'autocomplete' => [
             \Tempcord\Interfaces\Autocomplete::class,


### PR DESCRIPTION
Work that is not a reply to anything — sweeping rows that have run their course, expiring caches, polling a service with no gateway event of its own — had no home in the framework. Every bot reaches for `Loop::get()->addPeriodicTimer()` inside a plugin's `boot()` and then writes the same three safeguards, or more often does not write them.

```php
#[Scheduled(everySeconds: 10)]
final readonly class SweepTemporaryMessages
{
    public function __construct(private TempMessages $messages) {}

    public function __invoke(): void
    {
        $this->messages->sweep();
    }
}
```

Discovered like a command or a listener, built by the container, put on the loop before the gateway opens.

### Why this is not just sugar over `addPeriodicTimer`

A timer is less forgiving than an event listener — it fires again whether or not the last turn finished or threw, forever:

- **A task that throws is logged and keeps its place.** Otherwise the exception travels into the event loop; the usual result is a cancelled timer and nothing ever swept again — silently, because the bot carries on answering commands and looks healthy.
- **A task is never started alongside itself.** A turn still running when the next is due is skipped, and the skip logged. Without that, a task slower than its own interval makes every following turn slower until nothing else gets a look in.
- **Each turn runs in a fiber**, so a task may `await` the REST API exactly as a command handler does. This mirrors `EventDispatcher`.

### Deliberate choices worth arguing with

- **The first turn comes after the interval, not at boot.** A scheduled task is a repeating chore; one-off startup work (reconciling against what changed while the bot was down) belongs in a plugin's `boot()` where its ordering against everything else is visible. I left out an `immediately:` flag rather than guess.
- **A zero interval is refused at discovery**, since it asks the loop to run the task as fast as it can and starves the gateway heartbeat.
- **`start()` takes the loop as an argument** rather than reaching for `Loop::get()` itself, so the tests drive a `StreamSelectLoop` they own and the overlap and containment behaviour is exercised for real rather than mocked.

Adds a reference page and a guide; `composer docs` output is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)