### PR TITLE
feat(commands): take a backed enum as a command option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ Generated from the source, so it describes what the framework actually does.
 
 **Attributes** — [Command](reference/attributes/command.md), [SubcommandGroup](reference/attributes/subcommand-group.md), [Subcommand](reference/attributes/subcommand.md), [Option](reference/attributes/option.md), [Event](reference/attributes/event.md), [Autocomplete](reference/attributes/autocomplete.md), [Button](reference/attributes/button.md), [SelectMenu](reference/attributes/select-menu.md), [ModalSubmit](reference/attributes/modal-submit.md)
 
+**Options** — [Choosable](reference/options/choosable.md)
+
 **Autocomplete** — [Autocomplete](reference/autocomplete/autocomplete.md), [ArrayAutocomplete](reference/autocomplete/array-autocomplete.md)
 
 **Cache** — [Cache](reference/cache/cache.md)

--- a/docs/index.json
+++ b/docs/index.json
@@ -326,6 +326,24 @@
                 "methods": []
             }
         ],
+        "options": [
+            {
+                "name": "Choosable",
+                "fqcn": "Tempcord\\Interfaces\\Choosable",
+                "kind": "interface",
+                "target": null,
+                "summary": "An enum that says how each of its cases should read in Discord.",
+                "slug": "reference/options/choosable",
+                "parameters": [],
+                "cases": [],
+                "methods": [
+                    {
+                        "signature": "label(): string",
+                        "summary": "What a member reads when picking this case."
+                    }
+                ]
+            }
+        ],
         "autocomplete": [
             {
                 "name": "Autocomplete",

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,6 +14,10 @@
 - [SelectMenu](attributes/select-menu.md) — Declares a class or method as the handler for a select menu choice.
 - [ModalSubmit](attributes/modal-submit.md) — Declares a class or method as the handler for a submitted modal.
 
+## Options
+
+- [Choosable](options/choosable.md) — An enum that says how each of its cases should read in Discord.
+
 ## Autocomplete
 
 - [Autocomplete](autocomplete/autocomplete.md)

--- a/docs/reference/options/choosable.md
+++ b/docs/reference/options/choosable.md
@@ -1,0 +1,16 @@
+<!-- Generated from the source by `composer docs`. Do not edit by hand. -->
+
+# Choosable
+
+An enum that says how each of its cases should read in Discord.
+
+```php
+use Tempcord\Interfaces\Choosable;
+```
+
+## Methods
+
+### `label(): string`
+
+What a member reads when picking this case.
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,7 @@ parameters:
         - tools
     excludePaths:
         - tests/Fixtures
+    # Fixtures are not analysed — they exist to be malformed in interesting ways
+    # — but a test naming one still has to resolve to something.
+    scanDirectories:
+        - tests/Fixtures

--- a/src/Compiler/CommandCompiler.php
+++ b/src/Compiler/CommandCompiler.php
@@ -24,6 +24,8 @@ use Tempcord\Definitions\SubcommandGroupDefinition;
 use Tempcord\Interfaces\Autocomplete;
 use Tempcord\Localization\LocalizationProvider;
 use Tempcord\Localization\NullLocalizations;
+use ReflectionEnum;
+use Tempcord\Interfaces\Choosable;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Reflection\MethodReflector;
 use Tempest\Reflection\ParameterReflector;
@@ -242,7 +244,7 @@ final readonly class CommandCompiler
                 isRequired: !$parameter->isOptional(),
                 autocomplete: $this->autocompleteFor($option, $completers[$name] ?? null),
                 parameter: $parameter,
-                choices: $this->choicesOf($option),
+                choices: $this->choicesOf($option, $parameter),
                 minValue: $option->minValue,
                 maxValue: $option->maxValue,
                 minLength: $option->minLength,
@@ -312,10 +314,10 @@ final readonly class CommandCompiler
      *
      * @return array<string, string|int|float>
      */
-    private function choicesOf(Option $option): array
+    private function choicesOf(Option $option, ParameterReflector $parameter): array
     {
         if ($option->choices === []) {
-            return [];
+            return $this->casesOf($parameter);
         }
 
         if (!array_is_list($option->choices)) {
@@ -331,14 +333,68 @@ final readonly class CommandCompiler
         return $choices;
     }
 
+    /**
+     * Every case of an enum typed option, labelled the way the enum labels
+     * itself.
+     *
+     * Naming them is the whole reason to reach for an enum here rather than a
+     * string with a hand written choice list that has to be kept in step with
+     * it. An enum implementing Choosable says how each case reads; otherwise
+     * the case name is used, which is at least a name someone chose.
+     *
+     * @return array<string, string|int>
+     */
+    private function casesOf(ParameterReflector $parameter): array
+    {
+        if (!$parameter->getReflection()->hasType()) {
+            return [];
+        }
+
+        $name = $parameter->getType()->getName();
+
+        if (!self::isBackedEnum($name)) {
+            return [];
+        }
+
+        $choices = [];
+
+        foreach ($name::cases() as $case) {
+            $label = $case instanceof Choosable ? $case->label() : $case->name;
+            $choices[$label] = $case->value;
+        }
+
+        return $choices;
+    }
+
     private function typeOf(ParameterReflector $parameter): ApplicationCommandOptionType
     {
         if (!$parameter->getReflection()->hasType()) {
             throw new LogicException('Command option does not have type');
         }
 
-        return self::OPTION_TYPES[$parameter->getType()->getName()]
+        $name = $parameter->getType()->getName();
+
+        if (self::isBackedEnum($name)) {
+            /*
+             * Discord has no enum of its own; a backed enum is a fixed set of
+             * values, which is a string or an integer option whose choices
+             * happen to be all of them.
+             */
+            return (new ReflectionEnum($name))->getBackingType()?->getName() === 'int'
+                ? ApplicationCommandOptionType::INTEGER
+                : ApplicationCommandOptionType::STRING;
+        }
+
+        return self::OPTION_TYPES[$name]
             ?? throw new LogicException('Command option type not supported');
+    }
+
+    /**
+     * @phpstan-assert-if-true class-string<BackedEnum> $name
+     */
+    private static function isBackedEnum(string $name): bool
+    {
+        return is_subclass_of($name, BackedEnum::class);
     }
 
     /**

--- a/src/Interfaces/Choosable.php
+++ b/src/Interfaces/Choosable.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tempcord\Interfaces;
+
+/**
+ * An enum that says how each of its cases should read in Discord.
+ *
+ * An enum typed command option offers every case as a choice, and without this
+ * the case name is what a member sees — which is a PHP identifier, in English,
+ * and rarely what a bot wants shown. Implement this to name them properly.
+ *
+ *     enum Platform: string implements Choosable
+ *     {
+ *         case PC = 'PC';
+ *         case PlayStation = 'PS4';
+ *
+ *         public function label(): string
+ *         {
+ *             return match ($this) {
+ *                 self::PC => 'PC',
+ *                 self::PlayStation => 'PlayStation',
+ *             };
+ *         }
+ *     }
+ */
+interface Choosable
+{
+    /**
+     * What a member reads when picking this case.
+     */
+    public function label(): string;
+}

--- a/src/Runtime/ArgumentResolver.php
+++ b/src/Runtime/ArgumentResolver.php
@@ -46,7 +46,11 @@ final readonly class ArgumentResolver
                 continue;
             }
 
-            $supplied[$option->parameter->getName()] = $this->values->resolve($structure, $interaction);
+            $supplied[$option->parameter->getName()] = $this->values->resolve(
+                $structure,
+                $interaction,
+                $option->parameter,
+            );
         }
 
         $arguments = [];

--- a/src/Runtime/OptionValueResolver.php
+++ b/src/Runtime/OptionValueResolver.php
@@ -6,7 +6,9 @@ use Tempcord\Discord\Discord;
 use Tempcord\Discord\Enums\ApplicationCommandOptionType;
 use Tempcord\Discord\Interaction\CommandInteraction;
 use Tempcord\Discord\Parts\ApplicationCommandInteractionDataOptionStructure;
+use BackedEnum;
 use RuntimeException;
+use Tempest\Reflection\ParameterReflector;
 use Throwable;
 use function React\Async\await;
 
@@ -30,9 +32,14 @@ final readonly class OptionValueResolver
     public function resolve(
         ?ApplicationCommandInteractionDataOptionStructure $option,
         CommandInteraction $interaction,
+        ?ParameterReflector $parameter = null,
     ): mixed {
         if ($option === null) {
             return null;
+        }
+
+        if ($parameter !== null && $this->wantsEnum($parameter)) {
+            return $this->toEnum($option, $parameter);
         }
 
         return match ($option->type) {
@@ -54,5 +61,30 @@ final readonly class OptionValueResolver
             ),
             default => $option->value,
         };
+    }
+
+    private function wantsEnum(ParameterReflector $parameter): bool
+    {
+        return $parameter->getReflection()->hasType()
+            && is_subclass_of($parameter->getType()->getName(), BackedEnum::class);
+    }
+
+    /**
+     * Discord validates a choice against the list it was given, so a value that
+     * is not a case can only come from a client that made one up. Saying which
+     * option and which value beats a ValueError from deep inside from().
+     */
+    private function toEnum(
+        ApplicationCommandInteractionDataOptionStructure $option,
+        ParameterReflector $parameter,
+    ): BackedEnum {
+        /** @var class-string<BackedEnum> $enum */
+        $enum = $parameter->getType()->getName();
+        $backing = new \ReflectionEnum($enum)->getBackingType()?->getName();
+        $value = $backing === 'int' ? (int) $option->value : (string) $option->value;
+
+        return $enum::tryFrom($value) ?? throw new RuntimeException(
+            'Option [' . $option->name . '] was sent "' . $option->value . '", which is not a case of ' . $enum,
+        );
     }
 }

--- a/tests/Fixtures/Platform.php
+++ b/tests/Fixtures/Platform.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Interfaces\Choosable;
+
+enum Platform: string implements Choosable
+{
+    case PC = 'PC';
+    case PlayStation = 'PS4';
+    case Xbox = 'X1';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::PC => 'PC',
+            self::PlayStation => 'PlayStation',
+            self::Xbox => 'Xbox',
+        };
+    }
+}

--- a/tests/Fixtures/PlatformCommand.php
+++ b/tests/Fixtures/PlatformCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+use Tempcord\Attributes\Command;
+use Tempcord\Attributes\Option;
+use Tempcord\Discord\Interaction\CommandInteraction;
+
+#[Command(description: 'Looks a player up.')]
+final class PlatformCommand
+{
+    public static ?Platform $platform = null;
+
+    public static ?Region $region = null;
+
+    public function __invoke(
+        CommandInteraction $interaction,
+        #[Option(description: 'Where you play.')]
+        Platform $platform,
+        #[Option(description: 'Which region.')]
+        ?Region $region = null,
+    ): void {
+        self::$platform = $platform;
+        self::$region = $region;
+    }
+}

--- a/tests/Fixtures/Region.php
+++ b/tests/Fixtures/Region.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tempcord\Tests\Fixtures;
+
+/**
+ * A plain backed enum, which has no say in how its cases read.
+ */
+enum Region: int
+{
+    case Europe = 1;
+    case NorthAmerica = 2;
+}

--- a/tests/Unit/Compiler/EnumOptionTest.php
+++ b/tests/Unit/Compiler/EnumOptionTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tempcord\Tests\Unit\Compiler;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Tempcord\Compiler\CommandCompiler;
+use Tempcord\Discord\Enums\ApplicationCommandOptionType;
+use Tempcord\Discord\Gateway\Events\InteractionCreate;
+use Tempcord\Discord\Interaction\CommandInteraction;
+use Tempcord\Discord\Parts\ApplicationCommandInteractionDataOptionStructure;
+use Tempcord\Discord\Parts\InteractionData;
+use Tempcord\Interfaces\Choosable;
+use Tempcord\Runtime\ArgumentResolver;
+use Tempcord\Runtime\OptionValueResolver;
+use Tempcord\Tests\Doubles\FakeDiscord;
+use Tempcord\Tests\Doubles\RecordingHttp;
+use Tempcord\Tests\Fixtures\Platform;
+use Tempcord\Tests\Fixtures\PlatformCommand;
+use Tempcord\Tests\Fixtures\Region;
+use Tempcord\Tests\Unit\TestCase;
+use RuntimeException;
+
+/**
+ * An option typed as a backed enum.
+ *
+ * A fixed set of values written as a string plus a hand kept choice list is two
+ * places to change and one to forget. The framework already resolves enums for
+ * a component's arguments; a command's options were the one place it did not.
+ */
+#[CoversClass(CommandCompiler::class)]
+#[CoversClass(OptionValueResolver::class)]
+final class EnumOptionTest extends TestCase
+{
+    private function option(string $name): object
+    {
+        return $this->definition(PlatformCommand::class)->options[$name];
+    }
+
+    public function test_a_string_backed_enum_is_a_string_option(): void
+    {
+        $this->assertSame(ApplicationCommandOptionType::STRING, $this->option('platform')->type);
+    }
+
+    public function test_an_int_backed_enum_is_an_integer_option(): void
+    {
+        $this->assertSame(ApplicationCommandOptionType::INTEGER, $this->option('region')->type);
+    }
+
+    /**
+     * The whole point of reaching for an enum: the cases are the choices, so
+     * there is no second list to keep in step with it.
+     */
+    public function test_every_case_is_offered_as_a_choice(): void
+    {
+        $this->assertSame(
+            ['PC' => 'PC', 'PlayStation' => 'PS4', 'Xbox' => 'X1'],
+            $this->option('platform')->choices,
+        );
+    }
+
+    /**
+     * A case name is a PHP identifier and rarely what a bot wants shown, so an
+     * enum can say how each case reads.
+     */
+    public function test_a_choosable_enum_names_its_own_cases(): void
+    {
+        $this->assertContains(Choosable::class, class_implements(Platform::class));
+        $this->assertArrayHasKey('PlayStation', $this->option('platform')->choices);
+    }
+
+    /**
+     * Without that, the case name is used — at least a name somebody chose.
+     */
+    public function test_a_plain_enum_falls_back_to_its_case_names(): void
+    {
+        $this->assertSame(
+            ['Europe' => 1, 'NorthAmerica' => 2],
+            $this->option('region')->choices,
+        );
+    }
+
+    private function resolve(string $value, string $option = 'platform'): mixed
+    {
+        $structure = new ApplicationCommandInteractionDataOptionStructure();
+        $structure->name = $option;
+        $structure->type = $this->option($option)->type;
+        $structure->value = $value;
+
+        $data = new InteractionData();
+        $data->name = 'platform';
+        $data->options = [$structure];
+
+        $interaction = new InteractionCreate();
+        $interaction->id = '1';
+        $interaction->token = 'token';
+        $interaction->data = $data;
+
+        return new OptionValueResolver(new FakeDiscord(new RecordingHttp()))->resolve(
+            $structure,
+            new CommandInteraction($interaction, new FakeDiscord(new RecordingHttp())),
+            $this->option($option)->parameter,
+        );
+    }
+
+    public function test_the_handler_is_given_the_case_rather_than_the_value(): void
+    {
+        $this->assertSame(Platform::PlayStation, $this->resolve('PS4'));
+    }
+
+    public function test_an_int_backed_case_is_found_by_its_number(): void
+    {
+        $this->assertSame(Region::NorthAmerica, $this->resolve('2', 'region'));
+    }
+
+    /**
+     * Discord checks a choice against the list it was given, so a value that is
+     * not a case can only come from a client that made one up. Saying which
+     * option and which value beats a ValueError from deep inside from().
+     */
+    public function test_a_value_that_is_not_a_case_is_reported_clearly(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('is not a case of');
+
+        $this->resolve('Nintendo');
+    }
+}

--- a/tools/src/ApiReflector.php
+++ b/tools/src/ApiReflector.php
@@ -35,6 +35,9 @@ final readonly class ApiReflector
             \Tempcord\Attributes\SelectMenu::class,
             \Tempcord\Attributes\ModalSubmit::class,
         ],
+        'options' => [
+            \Tempcord\Interfaces\Choosable::class,
+        ],
         'autocomplete' => [
             \Tempcord\Interfaces\Autocomplete::class,
             \Tempcord\AutoCompletes\ArrayAutocomplete::class,


### PR DESCRIPTION
A fixed set of values had to be written as a string option with a choice list beside it:

```php
#[Option(description: 'Where you play.', choices: ['PC' => 'PC', 'PlayStation' => 'PS4', 'Xbox' => 'X1'])]
string $platform,
```

Two places to change and one to forget, and the handler still receives a bare string it has to validate itself.

```php
#[Option(description: 'Where you play.')]
Platform $platform,
```

The framework already resolved backed enums for a **component's** arguments (`ComponentArgumentResolver`); a command's options were the one place it did not. Now:

- a string-backed enum becomes a `STRING` option, an int-backed one an `INTEGER` option;
- every case is offered as a choice, unless `choices:` says otherwise;
- the handler is given the case, not the value.

### Naming the cases

A case name is a PHP identifier, in English, and rarely what a bot wants shown — `PlayStation` happens to read well, `NorthAmerica` does not. An enum may implement `Choosable` to say how each one reads:

```php
enum Platform: string implements Choosable
{
    case PlayStation = 'PS4';

    public function label(): string { /* ... */ }
}
```

Without it the case name is used, which is at least a name somebody chose.

### A value that is not a case

Discord checks a choice against the list it was given, so this can only come from a client that made one up. It names the option and the value rather than surfacing a `ValueError` from deep inside `from()`.

Also sets `scanDirectories` for `tests/Fixtures` — they are excluded from analysis, but a test naming one still has to resolve to something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)